### PR TITLE
fix: crash when used in conjunction with the app indexing

### DIFF
--- a/RNPushNotificationAndroid/src/main/java/com/dieam/reactnativepushnotification/ReactNativePushNotificationPackage.java
+++ b/RNPushNotificationAndroid/src/main/java/com/dieam/reactnativepushnotification/ReactNativePushNotificationPackage.java
@@ -44,6 +44,7 @@ public class ReactNativePushNotificationPackage implements ReactPackage {
     }
 
     public void newIntent(Intent intent) {
+        if(mRNPushNotification == null){ return; }
         mRNPushNotification.newIntent(intent);
     }
 }


### PR DESCRIPTION
fix: crash when used in conjunction with the app indexing
(If you call the "onNewIntent" in "Activity.onCreate")
https://developers.google.com/app-indexing/android/app?hl=en

Android 5.1.1
react-native 0.17