### PR TITLE
bug fix doens't extract the payload data on android

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,12 +156,7 @@ Notifications._onNotification = function(data, isFromBackground = null) {
 		} else {
 			this.onNotification({
 				foreground: ! isFromBackground,
-				message: data.message,
-				data: (
-					typeof data.data !== 'undefined'
-					? data.data
-					: {} 
-				),
+				...data
 			});
 		}
 	}


### PR DESCRIPTION
It seems that when sending a message like: 
`{
  "to" : "bk3RNwTe3H0:CI2k_HHwgIpoDKCIZvvDMExUdFQ3P1...", 
  "priority" : "normal", 
  "notification" : {
    "body" : "This week’s edition is now available.", 
    "title" : "NewsMagazine.com", 
    "icon" : "new", 
  }, 
  "data" : { 
    "volume" : "3.21.15", 
    "contents" : "http://www.news-magazine.com/world-week/21659772" 
  } 
} 
`

It doesn't extract the "data" the "data" is getting "splat" and therefore  typeof data.data === 'undefined'