### PR TITLE
Make it compatible with Parse push

### DIFF
--- a/RNPushNotificationAndroid/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/RNPushNotificationAndroid/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -7,6 +7,7 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ApplicationInfo;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -45,8 +46,14 @@ public class RNPushNotificationHelper {
         Resources res = mApplication.getResources();
         String packageName = mApplication.getPackageName();
 
+        String title = bundle.getString("title");
+        if (title == null) {
+          ApplicationInfo appInfo = mContext.getApplicationInfo();
+          title = mContext.getPackageManager().getApplicationLabel(appInfo).toString();
+        }
+
         NotificationCompat.Builder notification = new NotificationCompat.Builder(mContext)
-                .setContentTitle(bundle.getString("title"))
+                .setContentTitle(title)
                 .setContentText(bundle.getString("message"))
                 .setTicker(bundle.getString("ticker"))
                 .setCategory(NotificationCompat.CATEGORY_CALL)

--- a/RNPushNotificationAndroid/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
+++ b/RNPushNotificationAndroid/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
@@ -7,13 +7,33 @@ import android.app.ActivityManager.RunningAppProcessInfo;
 
 import java.util.List;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import com.google.android.gms.gcm.GcmListenerService;
 
 public class RNPushNotificationListenerService extends GcmListenerService {
 
     @Override
     public void onMessageReceived(String from, Bundle bundle) {
+        JSONObject data = getPushData(bundle.getString("data"));
+        if (data != null) {
+            if (!bundle.containsKey("message")) {
+                bundle.putString("message", data.optString("alert", "Notification received"));
+            }
+            if (!bundle.containsKey("title")) {
+                bundle.putString("title", data.optString("title", null));
+            }
+        }
         sendNotification(bundle);
+    }
+
+    private JSONObject getPushData(String dataString) {
+      try {
+          return new JSONObject(dataString);
+      } catch (JSONException e) {
+          return null;
+      }
     }
 
     private void sendNotification(Bundle bundle) {


### PR DESCRIPTION
Looks like Parse Cloud, when sending push notifications via GCM, [is storing all information about it in the `data` field](react-native-push-notification). This PR makes `react-native-push-notification` compatible with Parse Push, i.e. it will fallback to `data.alert` for notification's body and will use application's label as default title.