### PR TITLE
Android background notifications

### DIFF
--- a/RNPushNotificationAndroid/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/RNPushNotificationAndroid/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -47,12 +47,18 @@ public class RNPushNotificationHelper {
 
         NotificationCompat.Builder notification = new NotificationCompat.Builder(mContext)
                 .setContentTitle(bundle.getString("title"))
-                .setContentText(bundle.getString("message"))
                 .setTicker(bundle.getString("ticker"))
                 .setCategory(NotificationCompat.CATEGORY_CALL)
                 .setVisibility(NotificationCompat.VISIBILITY_PRIVATE)
                 .setPriority(NotificationCompat.PRIORITY_HIGH)
                 .setAutoCancel(true);
+
+        if (bundle.getString("message") != null) {
+            notification.setContentText(bundle.getString("message"));
+        } else {
+            this.cancelAll();
+            return;
+        }
 
         String largeIcon = bundle.getString("largeIcon");
 

--- a/RNPushNotificationAndroid/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
+++ b/RNPushNotificationAndroid/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
@@ -18,15 +18,16 @@ public class RNPushNotificationListenerService extends GcmListenerService {
 
     private void sendNotification(Bundle bundle) {
 
-        if (isApplicationRunning()) {
-            Intent intent = new Intent("RNPushNotificationReceiveNotification");
-            bundle.putBoolean("foreground", true);
-            intent.putExtra("notification", bundle);
-            sendBroadcast(intent);
-            return;
-        }
+        Boolean isRunning = isApplicationRunning();
+        
+        Intent intent = new Intent("RNPushNotificationReceiveNotification");
+        bundle.putBoolean("foreground", isRunning);
+        intent.putExtra("notification", bundle);
+        sendBroadcast(intent);
 
-        new RNPushNotificationHelper(getApplication(), this).sendNotification(bundle);
+        if (!isRunning) {
+            new RNPushNotificationHelper(getApplication(), this).sendNotification(bundle);
+        }
     }
 
     private boolean isApplicationRunning() {


### PR DESCRIPTION
PushNotificationsIOS delivers notifications to your react-native app even when it's not in the foreground. 

This update enables similar behaviour for Android. Additionally, it doesn't display a notification in the drawer if the message is blank. The use case for this is background-fetch.