### PR TITLE
Data payload support

### DIFF
--- a/RNPushNotificationAndroid/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/RNPushNotificationAndroid/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -56,6 +56,15 @@ public class RNPushNotification extends ReactContextBaseJavaModule {
             constants.put("initialNotification", bundleString);
         }
 
+        String data = intent.getStringExtra("data");
+        if (data != null) {
+          bundle = new Bundle();
+          bundle.putString("data", data);
+          bundle.putBoolean("foreground", false);
+          String bundleString = convertJSON(bundle);
+          constants.put("initialNotification", bundleString);
+        }
+
         return constants;
     }
 
@@ -70,6 +79,15 @@ public class RNPushNotification extends ReactContextBaseJavaModule {
             Bundle bundle = intent.getBundleExtra("notification");
             bundle.putBoolean("foreground", false);
             intent.putExtra("notification", bundle);
+            notifyNotification(bundle);
+        }
+
+        if ( intent.hasExtra("data") ) {
+            String data = intent.getStringExtra("data");
+            Bundle bundle = new Bundle();
+            bundle.putString("data", data);
+            bundle.putBoolean("foreground", false);
+            intent.putExtra("data", bundle);
             notifyNotification(bundle);
         }
     }


### PR DESCRIPTION
@zo0r Hi there, I have added support for the data string in a GCM payload. This resolves #41. I have tested it and it works perfectly for GCM payloads that contain both a "notification" and "data" object. Let me know if you'd prefer "else" on both of these "data" checks.