### PR TITLE
Do not call `cancelAll()` when the message is blank, return only

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -43,6 +43,10 @@ public class RNPushNotificationHelper {
             return;
         }
 
+        if (bundle.getString("message") == null) {
+            return;
+        }
+
         Resources res = mApplication.getResources();
         String packageName = mApplication.getPackageName();
 
@@ -60,12 +64,7 @@ public class RNPushNotificationHelper {
                 .setPriority(NotificationCompat.PRIORITY_HIGH)
                 .setAutoCancel(true);
 
-        if (bundle.getString("message") != null) {
-            notification.setContentText(bundle.getString("message"));
-        } else {
-            this.cancelAll();
-            return;
-        }
+        notification.setContentText(bundle.getString("message"));
 
         String largeIcon = bundle.getString("largeIcon");
 


### PR DESCRIPTION
Calling `cancelAll()` will remove all notifications currently in the notification drawer.

Related to #25.

