### PR TITLE
Restart React Native when app is destroyed via push notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,27 @@ Same parameters as `PushNotification.localNotification()`
 
 `PushNotification.abandonPermissions()` Abandon permissions
 
+## Restart React Native when App is Destroyed (Android Only)
+
+**For VoIP usage**
+
+If you are building a VoIP app and you don't want to make a background service to maintain a persistent connection between the app and the VoIP server, this will help you wake up your app in the foreground when a special push notification arrives.
+
+When sending GCM messages, set `"autoRestartReactActivity"="true"` under data payload.
+
+For example:
+
+```javascript
+payload = {
+    "to": "[Your-App-Token]",
+    "priority": "high",
+    "data": {
+        "message": "Hello!",
+        "autoRestartReactActivity": "true"
+    }
+}
+```
+
 ### TODO
 - [ ] Add `PushNotification.localNotificationSchedule()` Android support
 

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -27,6 +27,7 @@ public class RNPushNotification extends ReactContextBaseJavaModule {
     private ReactContext mReactContext;
     private Activity mActivity;
     private RNPushNotificationHelper mRNPushNotificationHelper;
+    private static final String ReceiveNotificationExtra  = "receiveNotifExtra";
 
     public RNPushNotification(ReactApplicationContext reactContext, Activity activity) {
         super(reactContext);
@@ -95,7 +96,13 @@ public class RNPushNotification extends ReactContextBaseJavaModule {
         mReactContext.registerReceiver(new BroadcastReceiver() {
             @Override
             public void onReceive(Context context, Intent intent) {
-                notifyNotification(intent.getBundleExtra("notification"));
+                if (getReactApplicationContext().hasActiveCatalystInstance()) {
+                    notifyNotification(intent.getBundleExtra("notification"));
+                    Bundle result = getResultExtras(true);
+                    result.putString(ReceiveNotificationExtra, "success");
+                    abortBroadcast();
+                } else {
+                }
             }
         }, intentFilter);
     }


### PR DESCRIPTION
## Motivation

When building a VoIP app, for user to be able to receive the call anytime we used to maintain a persistent connection between the app and the VoIP server even when the app is either in the background or get destroyed. This however drains the battery really fast and is also complicated to implement background services. On iOS it provides **PushKit** for this special circumstance while the only way to achieve the same thing on Android is using GCM high priority messages.

## Solution

Instead of waking up the app in the background for re-regiser to VoIP server when push notifications arrives we restart the react native activity to the foreground when receiving push notification with specific payload `"autoRestartReactActivity"="true"`.

**It will not affect the original behaviour as long as `autoRestartReactActivity` is not set or set to `false`.**

## Implementation Detail

### Use [sendOrderedBroadcast][1] instead of `sendBroadcast`

Because one can declare a `BroadcastReceiver()` in the third argument of `sendOrderedBroadcast`. This `BroadcastReceiver()` will be treated as the final receiver in the broadcast.

If the receiver in `RNPushNotification.java` module did receive the broadcast it will set an extra string `success` to the result and send it to the next broadcast receiver - which is our final receiver. Then in our final receiver we will restart the react native activity based on this extra string is set or not and if the payload of push notification has this special keyword: `autoRestartReactActivity` and is set to `true`.

### Start React Native using `startActivity()`

It will start our app in the foreground. Need to set the `FLAG_ACTIVITY_NEW_TASK` flag since there is no current activity when app is destroyed.

### Todos

May consider to add another option to start the app in the background.



[1]: http://developer.android.com/reference/android/content/Context.html#sendOrderedBroadcast