### PR TITLE
Lower the build tools dependency to match react-native's

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Hey,

I keep running into this issue trying to compile this with my app:

> failed to find Build Tools revision 23.0.2

After some trial and error I finally noticed that 23.0.2 is above the version that [React-Native itself uses](https://github.com/facebook/react-native/blob/ce1261a3dd2ac4a526b92689cd1e07e8af2d85ef/local-cli/generator-android/templates/src/app/build.gradle#L81). Can we lower the dependency here to match?

Thanks!