### PR TITLE
Add missing iOS Local Notification event listener

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ Notifications.unregister = function() {
  * @param {String}		details.message - The message displayed in the notification alert.
  * @param {String}		details.title  -  ANDROID ONLY: The title displayed in the notification alert.
  * @param {String}		details.ticker -  ANDROID ONLY: The ticker displayed in the status bar.
- * @param {Object}		details.data -  iOS ONLY: The userInfo used in the notification alert.
+ * @param {Object}		details.userInfo -  iOS ONLY: The userInfo used in the notification alert.
  */
 Notifications.localNotification = function(details: Object) {
 	if ( Platform.OS === 'ios' ) {

--- a/index.js
+++ b/index.js
@@ -72,6 +72,7 @@ Notifications.configure = function(options: Object) {
 	if ( this.loaded === false ) {
 		this.callNative( 'addEventListener', [ 'register', this._onRegister.bind(this) ] )
 		this.callNative( 'addEventListener', [ 'notification', this._onNotification.bind(this) ] )
+		this.callNative( 'addEventListener', [ 'localNotification', this._onNotification.bind(this) ] )
 
 		if ( typeof options.popInitialNotification === 'undefined' || options.popInitialNotification === true ) {
 			var tempFirstNotification = this.callNative( 'popInitialNotification' );
@@ -94,6 +95,7 @@ Notifications.configure = function(options: Object) {
 Notifications.unregister = function() {
 	this.callNative( 'removeEventListener', [ 'register', this._onRegister.bind(this) ] )
 	this.callNative( 'removeEventListener', [ 'notification', this._onNotification.bind(this) ] )
+	this.callNative( 'removeEventListener', [ 'localNotification', this._onNotification.bind(this) ] )
 };
 
 /**
@@ -106,7 +108,8 @@ Notifications.unregister = function() {
 Notifications.localNotification = function(details: Object) {
 	if ( Platform.OS === 'ios' ) {
 		this.handler.presentLocalNotification({
-			alertBody: details.message
+			alertBody: details.message,
+			userInfo: details.data,
 		});
 	} else {
 		this.handler.presentLocalNotification(details);

--- a/index.js
+++ b/index.js
@@ -104,12 +104,13 @@ Notifications.unregister = function() {
  * @param {String}		details.message - The message displayed in the notification alert.
  * @param {String}		details.title  -  ANDROID ONLY: The title displayed in the notification alert.
  * @param {String}		details.ticker -  ANDROID ONLY: The ticker displayed in the status bar.
+ * @param {Object}		details.data -  iOS ONLY: The userInfo used in the notification alert.
  */
 Notifications.localNotification = function(details: Object) {
 	if ( Platform.OS === 'ios' ) {
 		this.handler.presentLocalNotification({
 			alertBody: details.message,
-			userInfo: details.data,
+			userInfo: details.userInfo,
 		});
 	} else {
 		this.handler.presentLocalNotification(details);


### PR DESCRIPTION
When sending local notifications in iOS, the ```.onNotification``` handler passed during configuration was not being called.

The issue is that, on ```Notifications.configure``` in index.js, the ```localNotification``` event described in [React-Native's PushNotificationiOS](https://facebook.github.io/react-native/docs/pushnotificationios.html#addeventlistener) was not given a listener.

Also, for iOS local notifications, you are currently not able to give a ```userInfo``` object. This PR fixes that issue as well.