### PR TITLE
Allow latest RC version of React Native as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "git+ssh://git@github.com:zo0r/react-native-push-notification.git"
   },
   "peerDependencies": {
-    "react-native": ">=0.16"
+    "react-native": ">=0.16 || 0.27.0-rc2"
   },
   "rnpm": {
     "android": {


### PR DESCRIPTION
Without the ability to solve peerDependencies with NPM 3 it's temporary impossible to install RC versions of libraries (React Native) without allowing them in the peerDependencies. Since React Native is releasing RC's quite often it would be nice to make sure the latest RC is supported as peerDependency.

Maybe another solution is to use a wildcard instead.