### PR TITLE
Android: Handle nested notification bundle

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -52,8 +52,8 @@ public class RNPushNotification extends ReactContextBaseJavaModule {
         Bundle bundle = intent.getBundleExtra("notification");
         if ( bundle != null ) {
             bundle.putBoolean("foreground", false);
-            String bundleString = convertJSON(bundle);
-            constants.put("initialNotification", bundleString);
+            JSONObject bundleJson = convertJSON(bundle);
+            constants.put("initialNotification", bundleJson.toString());
         }
 
         return constants;
@@ -101,29 +101,32 @@ public class RNPushNotification extends ReactContextBaseJavaModule {
     }
 
     private void notifyNotification(Bundle bundle) {
-        String bundleString = convertJSON(bundle);
-
         WritableMap params = Arguments.createMap();
-        params.putString("dataJSON", bundleString);
+        JSONObject bundleJson = convertJSON(bundle);
+        params.putString("dataJSON", bundleJson.toString());
 
         sendEvent("remoteNotificationReceived", params);
     }
 
-    private String convertJSON(Bundle bundle) {
+    private JSONObject convertJSON(Bundle bundle) {
         JSONObject json = new JSONObject();
         Set<String> keys = bundle.keySet();
         for (String key : keys) {
             try {
+                Object obj = bundle.get(key);
+                if (obj instanceof Bundle) {
+                    obj = convertJSON((Bundle)obj);
+                }
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                    json.put(key, JSONObject.wrap(bundle.get(key)));
+                    json.put(key, JSONObject.wrap(obj));
                 } else {
-                    json.put(key, bundle.get(key));
+                    json.put(key, obj);
                 }
             } catch(JSONException e) {
                 return null;
             }
         }
-        return json.toString();
+        return json;
     }
 
     @ReactMethod


### PR DESCRIPTION
Setup: A backend is sending push notifications via GCM using XMPP. The
message uses the notification payload format, which is a JSON object
(see
https://developers.google.com/cloud-messaging/xmpp-server-ref#downstream-xmpp-messages-json).

Issue: On an Android device, the notification payload arrives as a
nested Bundle with key "notification", within the outer "notification"
Bundle that is passed to notifyNotification(). In its current form,
convertJSON() doesn't convert this nested Bundle into a string, and as
such, the notification payload is missing from the notification that
is passed to the onNotification() callback.

Fix: In convertJSON(), call itself recursively to convert nested
Bundles into JSON. Change the function's return type to JSONObject.
