### PR TITLE
Updated to use static method instead of this when popping initial notification

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ Notifications.configure = function(options: Object) {
 		if ( typeof options.popInitialNotification === 'undefined' || options.popInitialNotification === true ) {
 			this.popInitialNotification(function(firstNotification) {
 				if ( firstNotification !== null ) {
-					this._onNotification(firstNotification, true);
+					Notifications._onNotification(firstNotification, true);
 				}
 			});
 		}


### PR DESCRIPTION
Was running into a problem where on Android, calling `this._onNotification` in this place resulted in an undefined `this._onNotification`. Switching to `Notifications._onNotification` seems to have fixed the problem.
