### PR TITLE
Make notification push behave similar to iOS

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
@@ -39,13 +39,14 @@ public class RNPushNotificationListenerService extends GcmListenerService {
     private void sendNotification(Bundle bundle) {
 
         Boolean isRunning = isApplicationRunning();
-        
-        Intent intent = new Intent("RNPushNotificationReceiveNotification");
         bundle.putBoolean("foreground", isRunning);
-        intent.putExtra("notification", bundle);
-        sendBroadcast(intent);
 
-        if (!isRunning) {
+        Intent intent = new Intent("RNPushNotificationReceiveNotification");
+        intent.putExtra("notification", bundle);
+
+        if (isRunning && bundle.getString("message") != null) {
+            sendBroadcast(intent);
+        } else if (!isRunning) {
             new RNPushNotificationHelper(getApplication(), this).sendNotification(bundle);
         }
     }


### PR DESCRIPTION
This PR disable intent broadcast in Android when the application is in the background and the push message will generate a notification.

This make the Android's behavior similar to iOS: Only one push message will be received: when it is received by active application, or when the notification is tapped.

Potential breakage when the application rely on the background message to do something, but such behavior won't work in iOS anyway.