### PR TITLE
Add missing this binding to popInitialNotification callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ Notifications.configure = function(options: Object) {
 				if ( firstNotification !== null ) {
 					this._onNotification(firstNotification, true);
 				}
-			});
+			}.bind(this));
 		}
 
 		this.isLoaded = true;


### PR DESCRIPTION
When popInitialNotification is true and app is closed, clicking on a notification causes an app crash