### PR TITLE
Defined suffix-less index.js

### DIFF
--- a/component/index.js
+++ b/component/index.js
@@ -1,0 +1,5 @@
+// Define suffix-less index module for unit tests
+module.exports = {
+  state: {},
+  component: {}
+};


### PR DESCRIPTION
When running unit tests against a codebase that imports `react-native-push-notification`, the test fails because it's not able to import `./component`.

Create a dummy file to fix broken import. Test author can mock the module definition as they please, but the default behaviour should not prevent other tests from running, as it does now.