### PR TITLE
Upgrading to react-native 0.29

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,6 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.facebook.react:react-native:0.16.+'
+    compile 'com.facebook.react:react-native:0.19.+'
     compile 'com.google.android.gms:play-services-gcm:7.8.0'
 }

--- a/android/src/main/java/com/dieam/reactnativepushnotification/ReactNativePushNotificationPackage.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/ReactNativePushNotificationPackage.java
@@ -1,5 +1,6 @@
 package com.dieam.reactnativepushnotification;
 
+import android.app.Application;
 import android.app.Activity;
 import android.content.Intent;
 
@@ -15,11 +16,11 @@ import java.util.Arrays;
 import java.util.List;
 
 public class ReactNativePushNotificationPackage implements ReactPackage {
-    Activity mActivity;
+    Application mApplication;
     RNPushNotification mRNPushNotification;
 
-    public ReactNativePushNotificationPackage(Activity activity) {
-        mActivity = activity;
+    public ReactNativePushNotificationPackage(Application application) {
+        mApplication = application;
     }
 
     @Override
@@ -27,7 +28,7 @@ public class ReactNativePushNotificationPackage implements ReactPackage {
             ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();
 
-        mRNPushNotification = new RNPushNotification(reactContext, mActivity);
+        mRNPushNotification = new RNPushNotification(reactContext, mApplication);
 
         modules.add(mRNPushNotification);
         return modules;

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -1,6 +1,7 @@
 package com.dieam.reactnativepushnotification.modules;
 
 import android.app.Activity;
+import android.app.Application;
 import android.content.BroadcastReceiver;
 import android.content.Intent;
 import android.content.IntentFilter;
@@ -25,15 +26,15 @@ import android.content.Context;
 
 public class RNPushNotification extends ReactContextBaseJavaModule {
     private ReactContext mReactContext;
-    private Activity mActivity;
+    private Application mApplication;
     private RNPushNotificationHelper mRNPushNotificationHelper;
 
-    public RNPushNotification(ReactApplicationContext reactContext, Activity activity) {
+    public RNPushNotification(ReactApplicationContext reactContext, Application application) {
         super(reactContext);
 
-        mActivity = activity;
+        mApplication = application;
         mReactContext = reactContext;
-        mRNPushNotificationHelper = new RNPushNotificationHelper(activity.getApplication(), reactContext);
+        mRNPushNotificationHelper = new RNPushNotificationHelper(application, reactContext);
         registerNotificationsRegistration();
         registerNotificationsReceiveNotification();
     }
@@ -47,13 +48,17 @@ public class RNPushNotification extends ReactContextBaseJavaModule {
     public Map<String, Object> getConstants() {
         final Map<String, Object> constants = new HashMap<>();
 
-        Intent intent = mActivity.getIntent();
+        Activity activity = getCurrentActivity();
 
-        Bundle bundle = intent.getBundleExtra("notification");
-        if ( bundle != null ) {
-            bundle.putBoolean("foreground", false);
-            String bundleString = convertJSON(bundle);
-            constants.put("initialNotification", bundleString);
+        if (activity != null) {
+            Intent intent = activity.getIntent();
+
+            Bundle bundle = intent.getBundleExtra("notification");
+            if (bundle != null) {
+                bundle.putBoolean("foreground", false);
+                String bundleString = convertJSON(bundle);
+                constants.put("initialNotification", bundleString);
+            }
         }
 
         return constants;


### PR DESCRIPTION
This is a potential upgrade to 0.29.  Since what RNPushNotification really needs in its constructor is the Application object, I just pass this in instead of the activity and use getCurrentActivity in getConstants().

And now the MainApplication.java looks like this

```

public class MainApplication extends Application implements ReactApplication {

  private Application mApplication = this;

  private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
    @Override
    protected boolean getUseDeveloperSupport() {
      return BuildConfig.DEBUG;
    }

    @Override
    protected List<ReactPackage> getPackages() {
      return Arrays.<ReactPackage>asList(
          new MainReactPackage(),
          new ReactNativePushNotificationPackage(mApplication)
      );
    }
  };

  ...
```