### PR TITLE
Use onNewIntent from ActivityEventListener

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ In your `AndroidManifest.xml`
 				<category android:name="${applicationId}" />
 			</intent-filter>
 		</receiver>
-	
+
 		<receiver android:name="com.dieam.reactnativepushnotification.modules.RNPushNotificationPublisher" />
 		<service android:name="com.dieam.reactnativepushnotification.modules.RNPushNotificationRegistrationService"/>
 		<service
@@ -99,53 +99,23 @@ import com.dieam.reactnativepushnotification.ReactNativePushNotificationPackage;
 
 public class MainApplication extends Application implements ReactApplication {
 
-  private ReactNativePushNotificationPackage mReactNativePushNotificationPackage; // <------ Add Package Variable
-
-   ...
-
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
-    @Override
-    protected boolean getUseDeveloperSupport() {
-      return BuildConfig.DEBUG;
-    }
+      @Override
+      protected boolean getUseDeveloperSupport() {
+        return BuildConfig.DEBUG;
+      }
 
       @Override
       protected List<ReactPackage> getPackages() {
-      mReactNativePushNotificationPackage = new ReactNativePushNotificationPackage(); // <------ Initialize the Package
 
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
-          mReactNativePushNotificationPackage // <---- Add the Package
+          new ReactNativePushNotificationPackage() // <---- Add the Package
       );
     }
   };
 
-   // Add onNewIntent
-   public void onNewIntent(Intent intent) {
-      if ( mReactNativePushNotificationPackage != null ) {
-          mReactNativePushNotificationPackage.newIntent(intent);
-      }
-   }
-
-    ....
-}
-```
-
-Add `onNewIntent` (in `MainActivity.java`)
-
-```java
-import android.content.Intent; // <--- Import Intent
-
-public class MainActivity extends ReactActivity {
-   ...
-
-    // Add onNewIntent
-    @Override
-    public void onNewIntent(Intent intent) {
-        super.onNewIntent(intent);
-        ((MainApplication) getApplication()).onNewIntent(intent);
-    }
-    ....
+  ....
 }
 ```
 
@@ -256,4 +226,3 @@ Same parameters as `PushNotification.localNotification()`
 ### TODO
 - [X] Add `PushNotification.localNotificationSchedule()` Android support
 - [ ] Restore Android local notifications after reboot
-

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,6 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.facebook.react:react-native:0.19.+'
+    compile 'com.facebook.react:react-native:+'
     compile 'com.google.android.gms:play-services-gcm:7.8.0'
 }

--- a/android/src/main/java/com/dieam/reactnativepushnotification/ReactNativePushNotificationPackage.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/ReactNativePushNotificationPackage.java
@@ -1,7 +1,5 @@
 package com.dieam.reactnativepushnotification;
 
-import android.content.Intent;
-
 import com.dieam.reactnativepushnotification.modules.RNPushNotification;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
@@ -9,42 +7,24 @@ import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class ReactNativePushNotificationPackage implements ReactPackage {
-    RNPushNotification mRNPushNotification;
-
-    public ReactNativePushNotificationPackage() {}
-
     @Override
     public List<NativeModule> createNativeModules(
             ReactApplicationContext reactContext) {
-        List<NativeModule> modules = new ArrayList<>();
-
-        mRNPushNotification = new RNPushNotification(reactContext);
-
-        modules.add(mRNPushNotification);
-        return modules;
+        return Collections.<NativeModule>singletonList(new RNPushNotification(reactContext));
     }
 
     @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Arrays.asList();
+        return Collections.emptyList();
     }
 
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
-        return new ArrayList<>();
-    }
-
-    public void newIntent(Intent intent) {
-        if (mRNPushNotification == null){
-            return;
-        }
-
-        mRNPushNotification.newIntent(intent);
+        return Collections.emptyList();
     }
 }
 

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -3,13 +3,15 @@ package com.dieam.reactnativepushnotification.modules;
 import android.app.Activity;
 import android.app.Application;
 import android.content.BroadcastReceiver;
+import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Build;
 import android.os.Bundle;
 
-import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -18,23 +20,20 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.json.*;
-
-import android.content.Context;
-import android.util.Log;
-
-public class RNPushNotification extends ReactContextBaseJavaModule {
-    private ReactContext mReactContext;
+public class RNPushNotification extends ReactContextBaseJavaModule implements ActivityEventListener {
     private RNPushNotificationHelper mRNPushNotificationHelper;
 
     public RNPushNotification(ReactApplicationContext reactContext) {
         super(reactContext);
 
-        mReactContext = reactContext;
+        reactContext.addActivityEventListener(this);
         mRNPushNotificationHelper = new RNPushNotificationHelper((Application) reactContext.getApplicationContext());
         registerNotificationsRegistration();
         registerNotificationsReceiveNotification();
@@ -53,14 +52,17 @@ public class RNPushNotification extends ReactContextBaseJavaModule {
     }
 
     private void sendEvent(String eventName, Object params) {
-        if (mReactContext.hasActiveCatalystInstance()) {
-            mReactContext
+        ReactContext reactContext = getReactApplicationContext();
+
+        if (reactContext.hasActiveCatalystInstance()) {
+            reactContext
                     .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                     .emit(eventName, params);
         }
     }
 
-    public void newIntent(Intent intent) {
+    @Override
+    public void onNewIntent(Intent intent) {
         if (intent.hasExtra("notification")) {
             Bundle bundle = intent.getBundleExtra("notification");
             bundle.putBoolean("foreground", false);
@@ -72,7 +74,7 @@ public class RNPushNotification extends ReactContextBaseJavaModule {
     private void registerNotificationsRegistration() {
         IntentFilter intentFilter = new IntentFilter("RNPushNotificationRegisteredToken");
 
-        mReactContext.registerReceiver(new BroadcastReceiver() {
+        getReactApplicationContext().registerReceiver(new BroadcastReceiver() {
             @Override
             public void onReceive(Context context, Intent intent) {
                 String token = intent.getStringExtra("token");
@@ -86,10 +88,10 @@ public class RNPushNotification extends ReactContextBaseJavaModule {
 
     private void registerNotificationsReceiveNotification() {
         IntentFilter intentFilter = new IntentFilter("RNPushNotificationReceiveNotification");
-        mReactContext.registerReceiver(new BroadcastReceiver() {
+        getReactApplicationContext().registerReceiver(new BroadcastReceiver() {
             @Override
             public void onReceive(Context context, Intent intent) {
-                notifyNotification(intent.getBundleExtra("notification"));
+               notifyNotification(intent.getBundleExtra("notification"));
             }
         }, intentFilter);
     }
@@ -122,10 +124,12 @@ public class RNPushNotification extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void requestPermissions(String senderID) {
-        Intent GCMService = new Intent(mReactContext, RNPushNotificationRegistrationService.class);
+        ReactContext reactContext = getReactApplicationContext();
+
+        Intent GCMService = new Intent(reactContext, RNPushNotificationRegistrationService.class);
 
         GCMService.putExtra("senderID", senderID);
-        mReactContext.startService(GCMService);
+        reactContext.startService(GCMService);
     }
 
     @ReactMethod
@@ -161,4 +165,8 @@ public class RNPushNotification extends ReactContextBaseJavaModule {
         promise.resolve(params);
     }
 
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        // Ignored, required to implement ActivityEventListener
+    }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "git+ssh://git@github.com:zo0r/react-native-push-notification.git"
   },
   "peerDependencies": {
-    "react-native": ">=0.28"
+    "react-native": ">=0.30"
   },
   "rnpm": {
     "android": {


### PR DESCRIPTION
Hello,

React Native a new event in the 0.30 version , [`onNewIntent`](https://github.com/facebook/react-native/commit/2fc0f4041ec836c1e1aef1f5d9c77b4f4aba4aae), which allow us to know when the current activity receives a new intent without having to implement a method in `MainApplication` and `MainActivity`.

It simplifies the code a lot, even when implementing the module since we don't need to pass the event from the activity -> application -> module.

I tested it, it works fine.
