### PR TITLE
Change default vibration time to 300ms.

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -17,7 +17,7 @@ import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 
 public class RNPushNotificationHelper {
-    private static final long DEFAULT_VIBRATION = 1000L;
+    private static final long DEFAULT_VIBRATION = 300L;
     private static final String TAG = RNPushNotificationHelper.class.getSimpleName();
 
     private Context mContext;


### PR DESCRIPTION
The new default that was added is 1000ms which is too long. In my experience almost every notification uses the default time of 300ms (as actually documented in the README.md) which is more sensible for incoming messages, whereas 1000ms feels like the start of an alarm / phone call.