### PR TITLE
Android - added ShortcutBadger support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,5 +31,5 @@ dependencies {
     compile 'com.android.support:appcompat-v7:23.1.1'
     compile 'com.facebook.react:react-native:+'
     compile 'com.google.android.gms:play-services-gcm:7.8.0'
-    compile 'me.leolin:ShortcutBadger:1.1.6@aar'
+    compile 'me.leolin:ShortcutBadger:1.1.4@aar'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'com.android.library'
 
+repositories {
+    mavenCentral()
+}
+
 android {
     compileSdkVersion 23
     buildToolsVersion "23.0.1"
@@ -27,4 +31,5 @@ dependencies {
     compile 'com.android.support:appcompat-v7:23.1.1'
     compile 'com.facebook.react:react-native:+'
     compile 'com.google.android.gms:play-services-gcm:7.8.0'
+    compile 'me.leolin:ShortcutBadger:1.1.6@aar'
 }

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -231,6 +231,21 @@ public class RNPushNotificationHelper {
                 notification.setVibrate(new long[]{0, vibration});
             }
 
+            int badge = -1;
+            if (bundle.containsKey("badge")) {
+                try {
+                    String badgeAsString = bundle.getString("badge");
+                    if (badgeAsString != null) {
+                        badge = Integer.parseInt(badgeAsString);
+                    }
+                } catch (Exception e) {
+                    badge = -1;
+                }
+            }
+            if (badge > -1) {
+                ShortcutBadger.applyCount(mContext, badge);
+            }
+
             Notification info = notification.build();
             info.defaults |= Notification.DEFAULT_LIGHTS;
 
@@ -246,6 +261,8 @@ public class RNPushNotificationHelper {
     }
 
     public void cancelAll() {
+        ShortcutBadger.removeCount(mContext);
+
         NotificationManager notificationManager =
                 (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
 

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -15,6 +15,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.NotificationCompat;
 import android.util.Log;
+import me.leolin.shortcutbadger.ShortcutBadger;
 
 public class RNPushNotificationHelper {
     private static final long DEFAULT_VIBRATION = 300L;


### PR DESCRIPTION
A notification object containing `badge` field will set the the `unread notification counter` on the app icon.

A notification without the `badge` field will not affect the counter.

To reset the counter set the `badge` field to 0.

See ShortcutBadger for supported launchers.