### PR TITLE
Removes @override onNewIntent

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -61,7 +61,6 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
         }
     }
 
-    @Override
     public void onNewIntent(Intent intent) {
         if (intent.hasExtra("notification")) {
             Bundle bundle = intent.getBundleExtra("notification");


### PR DESCRIPTION
Since onNewIntent is a method from ActivityEventListener interface, it just needs to be implemented, not override. It was throwing an error with this method override.