### PR TITLE
sendBroadcast: make the intent of broadcast more unique by adding the package name

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -72,7 +72,7 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
     }
 
     private void registerNotificationsRegistration() {
-        IntentFilter intentFilter = new IntentFilter("RNPushNotificationRegisteredToken");
+        IntentFilter intentFilter = new IntentFilter(getReactApplicationContext().getPackageName() + ".RNPushNotificationRegisteredToken");
 
         getReactApplicationContext().registerReceiver(new BroadcastReceiver() {
             @Override
@@ -87,7 +87,7 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
     }
 
     private void registerNotificationsReceiveNotification() {
-        IntentFilter intentFilter = new IntentFilter("RNPushNotificationReceiveNotification");
+        IntentFilter intentFilter = new IntentFilter(getReactApplicationContext().getPackageName() + ".RNPushNotificationReceiveNotification");
         getReactApplicationContext().registerReceiver(new BroadcastReceiver() {
             @Override
             public void onReceive(Context context, Intent intent) {

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
@@ -40,7 +40,7 @@ public class RNPushNotificationListenerService extends GcmListenerService {
 
         Boolean isRunning = isApplicationRunning();
 
-        Intent intent = new Intent("RNPushNotificationReceiveNotification");
+        Intent intent = new Intent(this.getPackageName() + ".RNPushNotificationReceiveNotification");
         bundle.putBoolean("foreground", isRunning);
         bundle.putBoolean("userInteraction", false);
         intent.putExtra("notification", bundle);

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationRegistrationService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationRegistrationService.java
@@ -29,7 +29,7 @@ public class RNPushNotificationRegistrationService extends IntentService {
     }
 
     private void sendRegistrationToken(String token) {
-        Intent intent = new Intent("RNPushNotificationRegisteredToken");
+        Intent intent = new Intent(this.getPackageName() + ".RNPushNotificationRegisteredToken");
         intent.putExtra("token", token);
         sendBroadcast(intent);
     }


### PR DESCRIPTION
When I build 2 apps and both use this module, the `intent` of `sendBroadcast` on each app are the same therefore when the Registration/Notification received in one app the broadcast it sends will be received by all of the apps that listen to the same intent.

This PR solves this problem by adding `package name` prefix.