### PR TITLE
Don't pin down version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,5 +26,5 @@ dependencies {
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:23.1.1'
     compile 'com.facebook.react:react-native:+'
-    compile 'com.google.android.gms:play-services-gcm:7.8.0'
+    compile 'com.google.android.gms:play-services-gcm:+'
 }


### PR DESCRIPTION
This makes it incompatible with other plugins including `react-native-background-geolocation`.