### PR TITLE
Run onNotification() in JS, even when the app isn't running at all.

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Build;
 import android.os.Bundle;
+import android.util.Log;
 
 import com.dieam.reactnativepushnotification.helpers.ApplicationBadgeHelper;
 import com.facebook.react.bridge.ActivityEventListener;
@@ -120,7 +121,7 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
         }, intentFilter);
     }
 
-    private void notifyNotification(Bundle bundle) {
+    void notifyNotification(Bundle bundle) {
         String bundleString = convertJSON(bundle);
 
         WritableMap params = Arguments.createMap();

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -7,7 +7,6 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 
@@ -22,21 +21,17 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.modules.core.DeviceEventManagerModule;
-
-import org.json.JSONException;
-import org.json.JSONObject;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 
 public class RNPushNotification extends ReactContextBaseJavaModule implements ActivityEventListener {
     public static final String LOG_TAG = "RNPushNotification";// all logging should use this tag
 
     private RNPushNotificationHelper mRNPushNotificationHelper;
     private final Random mRandomNumberGenerator = new Random(System.currentTimeMillis());
+    private RNPushNotificationJsDelivery mJsDelivery;
 
     public RNPushNotification(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -44,11 +39,12 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
         reactContext.addActivityEventListener(this);
 
         Application applicationContext = (Application) reactContext.getApplicationContext();
+        // The @ReactNative methods use this
         mRNPushNotificationHelper = new RNPushNotificationHelper(applicationContext);
+        // This is used to delivery callbacks to JS
+        mJsDelivery = new RNPushNotificationJsDelivery(reactContext);
 
         registerNotificationsRegistration();
-        registerNotificationsReceiveNotification();
-        registerNotificationsRemoteFetch();
     }
 
     @Override
@@ -63,22 +59,12 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
         return constants;
     }
 
-    private void sendEvent(String eventName, Object params) {
-        ReactContext reactContext = getReactApplicationContext();
-
-        if (reactContext.hasActiveCatalystInstance()) {
-            reactContext
-                    .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                    .emit(eventName, params);
-        }
-    }
-
     public void onNewIntent(Intent intent) {
         if (intent.hasExtra("notification")) {
             Bundle bundle = intent.getBundleExtra("notification");
             bundle.putBoolean("foreground", false);
             intent.putExtra("notification", bundle);
-            notifyNotification(bundle);
+            mJsDelivery.notifyNotification(bundle);
         }
     }
 
@@ -92,42 +78,9 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
                 WritableMap params = Arguments.createMap();
                 params.putString("deviceToken", token);
 
-                sendEvent("remoteNotificationsRegistered", params);
+                mJsDelivery.sendEvent("remoteNotificationsRegistered", params);
             }
         }, intentFilter);
-    }
-
-    private void registerNotificationsReceiveNotification() {
-        IntentFilter intentFilter = new IntentFilter(getReactApplicationContext().getPackageName() + ".RNPushNotificationReceiveNotification");
-        getReactApplicationContext().registerReceiver(new BroadcastReceiver() {
-            @Override
-            public void onReceive(Context context, Intent intent) {
-                notifyNotification(intent.getBundleExtra("notification"));
-            }
-        }, intentFilter);
-    }
-
-    private void registerNotificationsRemoteFetch() {
-        IntentFilter intentFilter = new IntentFilter(getReactApplicationContext().getPackageName() + ".RNPushNotificationRemoteFetch");
-        getReactApplicationContext().registerReceiver(new BroadcastReceiver() {
-            @Override
-            public void onReceive(Context context, Intent intent) {
-                Bundle bundle = intent.getBundleExtra("notification");
-                String bundleString = convertJSON(bundle);
-                WritableMap params = Arguments.createMap();
-                params.putString("dataJSON", bundleString);
-                sendEvent("remoteFetch", params);
-            }
-        }, intentFilter);
-    }
-
-    void notifyNotification(Bundle bundle) {
-        String bundleString = convertJSON(bundle);
-
-        WritableMap params = Arguments.createMap();
-        params.putString("dataJSON", bundleString);
-
-        sendEvent("remoteNotificationReceived", params);
     }
 
     private void registerNotificationsReceiveNotificationActions(ReadableArray actions) {
@@ -143,7 +96,7 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
                 Bundle bundle = intent.getBundleExtra("notification");
 
                 // Notify the action.
-                notifyNotificationAction(bundle);
+                mJsDelivery.notifyNotificationAction(bundle);
 
                 // Dismiss the notification popup.
                 NotificationManager manager = (NotificationManager) context.getSystemService(context.NOTIFICATION_SERVICE);
@@ -151,32 +104,6 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
                 manager.cancel(notificationID);
             }
         }, intentFilter);
-    }
-
-    private void notifyNotificationAction(Bundle bundle) {
-        String bundleString = convertJSON(bundle);
-
-        WritableMap params = Arguments.createMap();
-        params.putString("dataJSON", bundleString);
-
-        sendEvent("notificationActionReceived", params);
-    }
-
-    private String convertJSON(Bundle bundle) {
-        JSONObject json = new JSONObject();
-        Set<String> keys = bundle.keySet();
-        for (String key : keys) {
-            try {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                    json.put(key, JSONObject.wrap(bundle.get(key)));
-                } else {
-                    json.put(key, bundle.get(key));
-                }
-            } catch (JSONException e) {
-                return null;
-            }
-        }
-        return json.toString();
     }
 
     @ReactMethod
@@ -218,7 +145,7 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
             Bundle bundle = intent.getBundleExtra("notification");
             if (bundle != null) {
                 bundle.putBoolean("foreground", false);
-                String bundleString = convertJSON(bundle);
+                String bundleString = mJsDelivery.convertJSON(bundle);
                 params.putString("dataJSON", bundleString);
             }
         }

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -137,7 +137,7 @@ public class RNPushNotificationHelper {
             }
 
             if (bundle.getString("message") == null) {
-                Log.e(LOG_TAG, "No message specified for the notification");
+                Log.e(LOG_TAG, "No message specified for the notification: " + bundle);
                 return;
             }
 

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationJsDelivery.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationJsDelivery.java
@@ -1,0 +1,80 @@
+package com.dieam.reactnativepushnotification.modules;
+
+import android.os.Build;
+import android.os.Bundle;
+import android.util.Log;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Set;
+
+import static com.dieam.reactnativepushnotification.modules.RNPushNotification.LOG_TAG;
+
+/**
+ * Created by lambert on 2016/10/09.
+ */
+
+public class RNPushNotificationJsDelivery {
+    private ReactApplicationContext mReactContext;
+
+    public RNPushNotificationJsDelivery(ReactApplicationContext reactContext) {
+        mReactContext = reactContext;
+    }
+
+    void sendEvent(String eventName, Object params) {
+        if (mReactContext.hasActiveCatalystInstance()) {
+            mReactContext
+                    .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                    .emit(eventName, params);
+        }
+    }
+
+    void notifyRemoteFetch(Bundle bundle) {
+        String bundleString = convertJSON(bundle);
+        WritableMap params = Arguments.createMap();
+        params.putString("dataJSON", bundleString);
+        sendEvent("remoteFetch", params);
+    }
+
+    void notifyNotification(Bundle bundle) {
+        String bundleString = convertJSON(bundle);
+
+        WritableMap params = Arguments.createMap();
+        params.putString("dataJSON", bundleString);
+
+        sendEvent("remoteNotificationReceived", params);
+    }
+
+    void notifyNotificationAction(Bundle bundle) {
+        String bundleString = convertJSON(bundle);
+
+        WritableMap params = Arguments.createMap();
+        params.putString("dataJSON", bundleString);
+
+        sendEvent("notificationActionReceived", params);
+    }
+
+    String convertJSON(Bundle bundle) {
+        JSONObject json = new JSONObject();
+        Set<String> keys = bundle.keySet();
+        for (String key : keys) {
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                    json.put(key, JSONObject.wrap(bundle.get(key)));
+                } else {
+                    json.put(key, bundle.get(key));
+                }
+            } catch (JSONException e) {
+                return null;
+            }
+        }
+        return json.toString();
+    }
+
+}

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
@@ -2,27 +2,22 @@ package com.dieam.reactnativepushnotification.modules;
 
 import android.app.ActivityManager;
 import android.app.ActivityManager.RunningAppProcessInfo;
-import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 
 import com.dieam.reactnativepushnotification.helpers.ApplicationBadgeHelper;
-import com.dieam.reactnativepushnotification.modules.RNPushNotification;
-import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
 import com.google.android.gms.gcm.GcmListenerService;
 
 import org.json.JSONObject;
 
-import java.lang.Runnable;
 import java.util.List;
 import java.util.Random;
-
-import static com.dieam.reactnativepushnotification.modules.RNPushNotification.LOG_TAG;
 
 public class RNPushNotificationListenerService extends GcmListenerService {
 
@@ -59,7 +54,7 @@ public class RNPushNotificationListenerService extends GcmListenerService {
                     // Otherwise wait for construction, then send the notification
                     mReactInstanceManager.addReactInstanceEventListener(new ReactInstanceManager.ReactInstanceEventListener() {
                         public void onReactContextInitialized(ReactContext context) {
-                            sendNotification((ReactApplicationContext)context, bundle);
+                          sendNotification((ReactApplicationContext)context, bundle);
                         }
                     });
                     if (!mReactInstanceManager.hasStartedCreatingInitialContext()) {
@@ -89,24 +84,14 @@ public class RNPushNotificationListenerService extends GcmListenerService {
 
         Boolean isRunning = isApplicationRunning();
 
-        Intent intent = new Intent(this.getPackageName() + ".RNPushNotificationReceiveNotification");
+        RNPushNotificationJsDelivery jsDelivery = new RNPushNotificationJsDelivery(context);
         bundle.putBoolean("foreground", isRunning);
         bundle.putBoolean("userInteraction", false);
-        intent.putExtra("notification", bundle);
-        sendBroadcast(intent);
+        jsDelivery.notifyNotification(bundle);
 
         // If contentAvailable is set to true, then send out a remote fetch event
         if (bundle.getString("contentAvailable", "false").equalsIgnoreCase("true")) {
-            Log.d(LOG_TAG, "Received a notification with remote fetch enabled");
-            Intent remoteFetchIntent = new Intent(this.getPackageName() + ".RNPushNotificationRemoteFetch");
-            remoteFetchIntent.putExtra("notification", bundle);
-            sendBroadcast(remoteFetchIntent);
-        }
-
-        if (!isRunning) {
-            // Run the notification on the JS thread
-            RNPushNotification pushNotification = new RNPushNotification(context);
-            pushNotification.notifyNotification(bundle);
+            jsDelivery.notifyRemoteFetch(bundle);
         }
     }
 

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
@@ -4,13 +4,21 @@ import android.app.ActivityManager;
 import android.app.ActivityManager.RunningAppProcessInfo;
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 
 import com.dieam.reactnativepushnotification.helpers.ApplicationBadgeHelper;
+import com.dieam.reactnativepushnotification.modules.RNPushNotification;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactInstanceManager;
 import com.google.android.gms.gcm.GcmListenerService;
 
 import org.json.JSONObject;
 
+import java.lang.Runnable;
 import java.util.List;
 import java.util.Random;
 
@@ -19,7 +27,7 @@ import static com.dieam.reactnativepushnotification.modules.RNPushNotification.L
 public class RNPushNotificationListenerService extends GcmListenerService {
 
     @Override
-    public void onMessageReceived(String from, Bundle bundle) {
+    public void onMessageReceived(String from, final Bundle bundle) {
         JSONObject data = getPushData(bundle.getString("data"));
         if (data != null) {
             if (!bundle.containsKey("message")) {
@@ -35,7 +43,32 @@ public class RNPushNotificationListenerService extends GcmListenerService {
             }
         }
 
-        sendNotification(bundle);
+        // We need to run this on the main thread, as the React code assumes that is true.
+        // Namely, DevServerHelper constructs a Handler() without a Looper, which triggers:
+        // "Can't create handler inside thread that has not called Looper.prepare()"
+        Handler handler = new Handler(Looper.getMainLooper());
+        handler.post(new Runnable() {
+            public void run() {
+                // Construct and load our normal React JS code bundle
+                ReactInstanceManager mReactInstanceManager = ((ReactApplication)getApplication()).getReactNativeHost().getReactInstanceManager();
+                ReactContext context = mReactInstanceManager.getCurrentReactContext();
+                // If it's constructed, send a notification
+                if (context != null) {
+                    sendNotification((ReactApplicationContext)context, bundle);
+                } else {
+                    // Otherwise wait for construction, then send the notification
+                    mReactInstanceManager.addReactInstanceEventListener(new ReactInstanceManager.ReactInstanceEventListener() {
+                        public void onReactContextInitialized(ReactContext context) {
+                            sendNotification((ReactApplicationContext)context, bundle);
+                        }
+                    });
+                    if (!mReactInstanceManager.hasStartedCreatingInitialContext()) {
+                        // Construct it in the background
+                        mReactInstanceManager.createReactContextInBackground();
+                    }
+                }
+            }
+        });
     }
 
     private JSONObject getPushData(String dataString) {
@@ -46,7 +79,7 @@ public class RNPushNotificationListenerService extends GcmListenerService {
         }
     }
 
-    private void sendNotification(Bundle bundle) {
+    private void sendNotification(ReactApplicationContext context, Bundle bundle) {
 
         // If notification ID is not provided by the user for push notification, generate one at random
         if (bundle.getString("id") == null) {
@@ -71,7 +104,9 @@ public class RNPushNotificationListenerService extends GcmListenerService {
         }
 
         if (!isRunning) {
-            new RNPushNotificationHelper(getApplication()).sendNotification(bundle);
+            // Run the notification on the JS thread
+            RNPushNotification pushNotification = new RNPushNotification(context);
+            pushNotification.notifyNotification(bundle);
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ var Notifications = {
 	onNotification: false,
   onRemoteFetch: false,
 	isLoaded: false,
+	hasPoppedInitialNotification: false,
 
 	isPermissionsRequestPending: false,
 
@@ -87,15 +88,14 @@ Notifications.configure = function(options: Object) {
 		this.isLoaded = true;
 	}
 
-	// Process popInitialNotification each time configure() is called, not only once-on-load.
-	// This allows us to popInitialNotification on a second call to configure().
-	if ( typeof options.popInitialNotification === 'undefined' ||
-		 options.popInitialNotification === true ) {
+	if ( this.hasPoppedInitialNotification === false &&
+			( options.popInitialNotification === undefined || options.popInitialNotification === true ) ) {
 		this.popInitialNotification(function(firstNotification) {
 			if ( firstNotification !== null ) {
 				this._onNotification(firstNotification, true);
 			}
 		}.bind(this));
+		this.hasPoppedInitialNotification = true;
 	}
 
 	if ( options.requestPermissions !== false ) {

--- a/index.js
+++ b/index.js
@@ -84,16 +84,18 @@ Notifications.configure = function(options: Object) {
 		this.callNative( 'addEventListener', [ 'localNotification', this._onNotification ] );
 		Platform.OS === 'android' ? this.callNative( 'addEventListener', [ 'remoteFetch', this._onRemoteFetch ] ) : null
 
-		if ( typeof options.popInitialNotification === 'undefined' ||
-			 options.popInitialNotification === true ) {
-			this.popInitialNotification(function(firstNotification) {
-				if ( firstNotification !== null ) {
-					this._onNotification(firstNotification, true);
-				}
-			}.bind(this));
-		}
-
 		this.isLoaded = true;
+	}
+
+	// Process popInitialNotification each time configure() is called, not only once-on-load.
+	// This allows us to popInitialNotification on a second call to configure().
+	if ( typeof options.popInitialNotification === 'undefined' ||
+		 options.popInitialNotification === true ) {
+		this.popInitialNotification(function(firstNotification) {
+			if ( firstNotification !== null ) {
+				this._onNotification(firstNotification, true);
+			}
+		}.bind(this));
 	}
 
 	if ( options.requestPermissions !== false ) {


### PR DESCRIPTION
Make the background listener service start the React JS application (sans Components), and then uses the results of any PushNotification.configure() calls to trigger the JS-based onNotification from the listener service.

This avoids the need to package everything into the Android notification payload to get it to show up, and should hopefully fix a bunch of open issues against this repo.

Note, I haven't explored what's required to get this equivalent functionality working on iOS (and I suspect it may not even be possible at all). But this helps me avoid duplicating functionality on Android and JS by letting me combine it.

I suspect there is additional work that might help combine other native-Android notification processing (RNPushNotificationPublisher and RNPushNotificationBootEventReceiver?) to get them to use JS notification processing. But I don't use them, so they are not in my critical path, and am worried I might break them, since playing with this code is a bit tricky to get right (with threads and the many ways Android notifications can be delivered, etc).