### PR TITLE
fixed scheduleLocalNotification to work on iOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ Notifications.localNotification = function(details: Object) {
 Notifications.localNotificationSchedule = function(details: Object) {
 	if ( Platform.OS === 'ios' ) {
 		this.handler.scheduleLocalNotification({
-			fireDate: details.date,
+			fireDate: details.date.toISOString(),
 			alertBody: details.message,
 			userInfo: details.userInfo
 		});
@@ -182,7 +182,7 @@ Notifications._onRemoteFetch = function(notificationData: Object) {
 	if ( this.onRemoteFetch !== false ) {
 		this.onRemoteFetch(notificationData)
 	}
-} 
+}
 
 Notifications._onNotification = function(data, isFromBackground = null) {
 	if ( isFromBackground === null ) {


### PR DESCRIPTION
This has been addressed here: #56

I added the .toISOString(), so there will be no error when scheduling notifications on iOS.