### PR TITLE
set isLoaded to false when unregister

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,6 +110,7 @@ Notifications.unregister = function() {
 	this.callNative( 'removeEventListener', [ 'notification', this._onNotification ] )
 	this.callNative( 'removeEventListener', [ 'localNotification', this._onNotification ] )
 	Platform.OS === 'android' ? this.callNative( 'removeEventListener', [ 'remoteFetch', this._onRemoteFetch ] ) : null
+	this.isLoaded = false;
 };
 
 /**


### PR DESCRIPTION
When I call `unregister()` and then call `configure()`, since `this.isLoaded` is true already the event listeners will not be set. So the `_onRegister()` and `_onNotification()` callback will not be called either. This PR fixes this by setting `this.isLoaded` to false when calling `unregister()`.
