### PR TITLE
[Android] Remote notifications should be added to the notifications centre when app is not running

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
@@ -1,5 +1,6 @@
 package com.dieam.reactnativepushnotification.modules;
 
+import android.app.Application;
 import android.app.ActivityManager;
 import android.app.ActivityManager.RunningAppProcessInfo;
 import android.os.Bundle;
@@ -19,6 +20,8 @@ import org.json.JSONObject;
 import java.util.List;
 import java.util.Random;
 
+import static com.dieam.reactnativepushnotification.modules.RNPushNotification.LOG_TAG;
+
 public class RNPushNotificationListenerService extends GcmListenerService {
 
     @Override
@@ -37,6 +40,8 @@ public class RNPushNotificationListenerService extends GcmListenerService {
                 ApplicationBadgeHelper.INSTANCE.setApplicationIconBadgeNumber(this, badge);
             }
         }
+
+        Log.e(LOG_TAG, "RNPushNotificationListenerService.onMessageReceived: " + bundle);
 
         // We need to run this on the main thread, as the React code assumes that is true.
         // Namely, DevServerHelper constructs a Handler() without a Looper, which triggers:
@@ -92,6 +97,14 @@ public class RNPushNotificationListenerService extends GcmListenerService {
         // If contentAvailable is set to true, then send out a remote fetch event
         if (bundle.getString("contentAvailable", "false").equalsIgnoreCase("true")) {
             jsDelivery.notifyRemoteFetch(bundle);
+        }
+
+        Log.e(LOG_TAG, "RNPushNotificationListenerService.sendNotification: " + bundle);
+
+        if (!isRunning) {
+            Application applicationContext = (Application) context.getApplicationContext();
+            RNPushNotificationHelper pushNotificationHelper = new RNPushNotificationHelper(applicationContext);
+            pushNotificationHelper.sendNotification(bundle);
         }
     }
 

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
@@ -87,10 +87,10 @@ public class RNPushNotificationListenerService extends GcmListenerService {
             bundle.putString("id", String.valueOf(randomNumberGenerator.nextInt()));
         }
 
-        Boolean isRunning = isApplicationRunning();
+        Boolean isForeground = isApplicationInForeground();
 
         RNPushNotificationJsDelivery jsDelivery = new RNPushNotificationJsDelivery(context);
-        bundle.putBoolean("foreground", isRunning);
+        bundle.putBoolean("foreground", isForeground);
         bundle.putBoolean("userInteraction", false);
         jsDelivery.notifyNotification(bundle);
 
@@ -101,14 +101,14 @@ public class RNPushNotificationListenerService extends GcmListenerService {
 
         Log.e(LOG_TAG, "RNPushNotificationListenerService.sendNotification: " + bundle);
 
-        if (!isRunning) {
+        if (!isForeground) {
             Application applicationContext = (Application) context.getApplicationContext();
             RNPushNotificationHelper pushNotificationHelper = new RNPushNotificationHelper(applicationContext);
             pushNotificationHelper.sendNotification(bundle);
         }
     }
 
-    private boolean isApplicationRunning() {
+    private boolean isApplicationInForeground() {
         ActivityManager activityManager = (ActivityManager) this.getSystemService(ACTIVITY_SERVICE);
         List<RunningAppProcessInfo> processInfos = activityManager.getRunningAppProcesses();
         for (RunningAppProcessInfo processInfo : processInfos) {


### PR DESCRIPTION
Call RNPushNotificationHelper.sendNotification when a notification arrives and app is not running to present a notification to the user