### PR TITLE
Use event type as the key instead of the handler to store in the handler map

### DIFF
--- a/component/index.android.js
+++ b/component/index.android.js
@@ -88,16 +88,16 @@ NotificationsComponent.prototype.addEventListener = function(type: string, handl
 		);
 	}
 
-	_notifHandlers.set(handler, listener);
+	_notifHandlers.set(type, listener);
 };
 
 NotificationsComponent.prototype.removeEventListener = function(type: string, handler: Function) {
-	var listener = _notifHandlers.get(handler);
+	var listener = _notifHandlers.get(type);
 	if (!listener) {
 		return;
 	}
 	listener.remove();
-	_notifHandlers.delete(handler);
+	_notifHandlers.delete(type);
 }
 
 NotificationsComponent.prototype.registerNotificationActions = function(details: Object) {


### PR DESCRIPTION
Please refer to facebook/react-native#10776

This PR fixes the collision when 2 handlers are the same. For instance, in this module's [index.js][1], both remote and local notification use the same handler.

[1]: https://github.com/zo0r/react-native-push-notification/blob/master/index.js#L84-L85