### PR TITLE
Feature: cancel a scheduled notification by its ID

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -183,6 +183,14 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
 
     @ReactMethod
     /**
+     * Cancel a scheduled notifications by Id and removes notification from the notification centre.
+     */
+    public void cancelLocalNotificationById(String notificationIDString) {
+        mRNPushNotificationHelper.cancelScheduledNotificationById(notificationIDString);
+    }
+
+    @ReactMethod
+    /**
      * Cancel scheduled notifications, and removes notifications from the notification centre.
      *
      * Note - as we are trying to achieve feature parity with iOS, this method cannot be used

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -430,6 +430,10 @@ public class RNPushNotificationHelper {
         }
     }
 
+    public void cancelScheduledNotificationById(String notificationIDString) {
+        cancelScheduledNotification(notificationIDString);
+    }
+
     private void cancelScheduledNotification(String notificationIDString) {
         Log.i(LOG_TAG, "Cancelling notification: " + notificationIDString);
 

--- a/component/index.android.js
+++ b/component/index.android.js
@@ -34,6 +34,10 @@ NotificationsComponent.prototype.cancelLocalNotifications = function(details: Ob
 	RNPushNotification.cancelLocalNotifications(details);
 };
 
+NotificationsComponent.prototype.cancelLocalNotificationById = function(id: string) {
+    RNPushNotification.cancelLocalNotificationById(id);
+};
+
 NotificationsComponent.prototype.cancelAllLocalNotifications = function() {
 	RNPushNotification.cancelAllLocalNotifications();
 };

--- a/index.js
+++ b/index.js
@@ -262,6 +262,10 @@ Notifications.cancelLocalNotifications = function() {
 	return this.callNative('cancelLocalNotifications', arguments);
 };
 
+Notifications.cancelLocalNotificationById = function() {
+	return this.callNative('cancelLocalNotificationById', arguments);
+};
+
 Notifications.cancelAllLocalNotifications = function() {
 	return this.callNative('cancelAllLocalNotifications', arguments);
 };


### PR DESCRIPTION
This feature is created because `cancelLocalNotifications` does not work at all for some reason.

So to make it simple, just pass the id of the notification to remove from the notification centre.
All you have to do is
```
const id = "NOTIFICATION_ID";
PushNotification.cancelLocalNotificationById(id);
```