### PR TITLE
Add badge and soundName properties to local notification schedule

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,9 +155,18 @@ Notifications.localNotification = function(details: Object) {
  */
 Notifications.localNotificationSchedule = function(details: Object) {
 	if ( Platform.OS === 'ios' ) {
+
+		let soundName = details.soundName ? details.soundName : 'default'; // play sound (and vibrate) as default behaviour
+
+		if (details.hasOwnProperty('playSound') && !details.playSound) {
+			soundName = ''; // empty string results in no sound (and no vibration)
+		}
+
 		this.handler.scheduleLocalNotification({
 			fireDate: details.date.toISOString(),
 			alertBody: details.message,
+			soundName: soundName,
+			applicationIconBadgeNumber: parseInt(details.number, 10),
 			userInfo: details.userInfo
 		});
 	} else {
@@ -181,7 +190,7 @@ Notifications._onRemoteFetch = function(notificationData: Object) {
 	if ( this.onRemoteFetch !== false ) {
 		this.onRemoteFetch(notificationData)
 	}
-}
+};
 
 Notifications._onNotification = function(data, isFromBackground = null) {
 	if ( isFromBackground === null ) {


### PR DESCRIPTION
I'm using local notification with badges on iOS, here's a pull request for support. I've sticked to the same syntax. The PushNotificationIOS library expects an integer for the applicationIconBadgeNumber.