### PR TITLE
Support for nested notification bundle

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -141,8 +141,9 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
         Activity activity = getCurrentActivity();
         if (activity != null) {
             Intent intent = activity.getIntent();
-            Bundle bundle = intent.getBundleExtra("notification");
-            if (bundle != null) {
+
+            if (intent.hasExtra("google.message_id")) {
+                Bundle bundle = intent.getExtras();
                 bundle.putBoolean("foreground", false);
                 String bundleString = mJsDelivery.convertJSON(bundle);
                 params.putString("dataJSON", bundleString);

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -141,9 +141,8 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
         Activity activity = getCurrentActivity();
         if (activity != null) {
             Intent intent = activity.getIntent();
-
-            if (intent.hasExtra("google.message_id")) {
-                Bundle bundle = intent.getExtras();
+            Bundle bundle = intent.getBundleExtra("notification");
+            if (bundle != null) {
                 bundle.putBoolean("foreground", false);
                 String bundleString = mJsDelivery.convertJSON(bundle);
                 params.putString("dataJSON", bundleString);

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationJsDelivery.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationJsDelivery.java
@@ -56,22 +56,32 @@ public class RNPushNotificationJsDelivery {
 
         sendEvent("notificationActionReceived", params);
     }
-
-    String convertJSON(Bundle bundle) {
+    String convertJSON(Bundle bundle){
+        JSONObject json = this.convertJSONNested(bundle);
+        if(json == null){
+            return null;
+        }
+        return json.toString();
+    }
+    JSONObject convertJSONNested(Bundle bundle){
         JSONObject json = new JSONObject();
         Set<String> keys = bundle.keySet();
         for (String key : keys) {
             try {
+                Object obj = bundle.get(key);
+                if (obj instanceof Bundle) {
+                    obj = convertJSONNested((Bundle)obj);
+                }
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                    json.put(key, JSONObject.wrap(bundle.get(key)));
+                    json.put(key, JSONObject.wrap(obj));
                 } else {
-                    json.put(key, bundle.get(key));
+                    json.put(key, obj);
                 }
             } catch (JSONException e) {
                 return null;
             }
         }
-        return json.toString();
+        return json;
     }
 
 }


### PR DESCRIPTION
I couldn't edit the existing Pull Request https://github.com/zo0r/react-native-push-notification/pull/86 so I created this. Also the changes are less significant and real easy to review.

Currently you are not supporting nested notification bundles like already described in here https://github.com/zo0r/react-native-push-notification/pull/86

In the "new" gcm/firebase version of Android its possible to send data and notification json. To access this data in react native this library needs to also parse nested json separately since JSONObject.wrap doesn't support the bundle datatype. I added it to the existing convertJSON by changing convertJSON to convertJSONNested and the existing convertJSON using the newly created convertJSONNested. Please have a look.