### PR TITLE
check if it’s a remote notification and pass all the data transferred…

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -141,8 +141,9 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
         Activity activity = getCurrentActivity();
         if (activity != null) {
             Intent intent = activity.getIntent();
-            Bundle bundle = intent.getBundleExtra("notification");
-            if (bundle != null) {
+
+            if (intent.hasExtra("google.message_id")) {
+                Bundle bundle = intent.getExtras();
                 bundle.putBoolean("foreground", false);
                 String bundleString = mJsDelivery.convertJSON(bundle);
                 params.putString("dataJSON", bundleString);


### PR DESCRIPTION
"notification" is actually not set with google remote messages if you open the app after a click on the notification on android, so we need to check for google.message_id instead and then transfer the properties send with the data object, so that they can be read inside of the app.