### PR TITLE
Add the npm --save flag in the installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ React Native Local and Remote Notifications for iOS and Android
 
 
 ## Installation
-`npm install react-native-push-notification`
+`npm install --save react-native-push-notification`
 
 `react-native link`
 


### PR DESCRIPTION
Add the npm `--save` flag in the installation documentation

From the [docs](https://facebook.github.io/react-native/docs/linking-libraries-ios.html#step-1):

> --save or --save-dev flag is very important for this step. React Native will link your libs based on dependencies and devDependencies in your package.json file.

This has been discussed in #318 
Probably fixes #361