### PR TITLE
[Android] handle mixed notification onNewIntent and getInitialNotification

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -71,6 +71,7 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
       Bundle bundle = getNotificationBundle(intent);
         if (bundle != null) {
             bundle.putBoolean("foreground", false);
+            bundle.putBoolean("userInteraction", true);
             intent.putExtra("notification", bundle);
             mJsDelivery.notifyNotification(bundle);
         }

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -58,9 +58,18 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
         return constants;
     }
 
+    private Bundle getNotificationBundle(Intent intent) {
+      if (intent.hasExtra("notification")) {
+        return intent.getBundleExtra("notification");
+      } else if (intent.hasExtra("google.message_id")) {
+        return intent.getExtras();
+      }
+      return null;
+    }
+
     public void onNewIntent(Intent intent) {
-        if (intent.hasExtra("notification")) {
-            Bundle bundle = intent.getBundleExtra("notification");
+      Bundle bundle = getNotificationBundle(intent);
+        if (bundle != null) {
             bundle.putBoolean("foreground", false);
             intent.putExtra("notification", bundle);
             mJsDelivery.notifyNotification(bundle);
@@ -141,7 +150,7 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
         Activity activity = getCurrentActivity();
         if (activity != null) {
             Intent intent = activity.getIntent();
-            Bundle bundle = intent.getBundleExtra("notification");
+            Bundle bundle = getNotificationBundle(intent);
             if (bundle != null) {
                 bundle.putBoolean("foreground", false);
                 String bundleString = mJsDelivery.convertJSON(bundle);


### PR DESCRIPTION
Broadcast onNotification to JS thread when receiving a mixed notifcation (with data and notification).
This will check if the intent has `notification` or `google.message_id` to know if intent is from GCM notification.
This will be useful for those who are using GCM on iOS and android like me.