### PR TITLE
use _onNotification as handler in popInitialNotification if no handler is provided

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["react-native"]
+}

--- a/README.md
+++ b/README.md
@@ -212,6 +212,13 @@ PushNotification.localNotification({
 });
 ```
 
+## Handling Initial Notification
+By default the initial notification is popped automatically.
+
+To manually pop the initial notification configure the `popInitialNotification` value to `false` and call `PushNotification.popInitialNotification()`. This will result in your `onNotification` handler being called with the initial notification.
+
+Optionally pass a custom handler function to the `PushNotification.popInitialNotification` method if you would like to have a different handler for initial notifications than the `onNotification` handler.
+
 ## Scheduled Notifications
 `PushNotification.localNotificationSchedule(details: Object)`
 

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,0 +1,100 @@
+'use strict';
+
+import 'react-native';
+
+describe('Test popInitialNotification method', function() {
+    let Index;
+    const mockIOSNotification = '{"_data":{"msgType":"iosTest","smallIcon":"notification_icon","notificationId":"463eec63-0470-40a9-85aa-c4c3554375cb","remote":true,"largeIcon":"notification_icon","testUrl":"http://google.com","notificationType":"debug","timestamp":1495956902971},"_remoteNotificationCompleteCalllbackCalled":false,"_isRemote":true,"_notificationId":"463eec63-0470-40a9-85aa-c4c3554375cb","_alert":"Got Push!","_sound":"default","_badgeCount":1}';
+    const mockAndroidNotification = '{"google.sent_time":1495978487418,"smallIcon":"notification_icon","userInteraction":true,"testUrl":"http://google.com","id":"-198084357","timestamp":"1495978487399","notId":"-534853452","title":"Got Push !","google.message_id":"0:1495978487425830%5336a3cef9fd7ecd","largeIcon":"notification_icon","notificationId":"0cd2ab63-2745-4d99-ab31-d12b9493db7c","message":"How awesome..","msgType":"androidTest","notificationType":"debug","foreground":false}';
+    let mockNotification;
+
+    function testWithNoCustomHandler(done){
+        const mockOnNotification = jest.fn();
+        Index._onNotification = mockOnNotification;
+        Index.popInitialNotification();
+        setTimeout(function () {
+            expect(mockOnNotification).toBeCalledWith(JSON.parse(mockNotification), true);
+            done();
+        }, 300);
+
+    };
+
+    function testWithCustomHandler(done){
+        const mockOnNotification = jest.fn();
+        const mockCustomHandler = jest.fn();
+        Index._onNotification = mockOnNotification;
+        Index.popInitialNotification(mockCustomHandler);
+        setTimeout(function () {
+            expect(mockOnNotification).not.toBeCalled();
+            expect(mockCustomHandler).toBeCalledWith(JSON.parse(mockNotification));
+            done();
+        }, 300);
+
+    }
+
+    function testWithPopInitialConfigurationTrue(done){
+        const mockOnNotification = jest.fn();
+        Index._onNotification = mockOnNotification;
+        Index.configure({
+            requestPermissions: false,
+            popInitialNotification: true
+        });
+
+        setTimeout(function () {
+            expect(mockOnNotification).toBeCalledWith(JSON.parse(mockNotification), true);
+            done();
+        }, 300);
+
+    }
+
+    describe('on iOS', function(){
+        beforeAll(function(){
+            jest.mock('PushNotificationIOS', function() {
+                return {
+                    getInitialNotification: function() {
+                        return new Promise(function(resolve){
+                            resolve(JSON.parse(mockIOSNotification));
+                        });
+                    }
+                };
+            });
+            Index = require('../index');
+            mockNotification = mockIOSNotification;
+        });
+
+        it('with no custom handler', testWithNoCustomHandler);
+
+        it('with custom handler', testWithCustomHandler);
+
+        it('with popInitialNotification configuration set to true', testWithPopInitialConfigurationTrue);
+    });
+
+    describe('on Android', function(){
+        beforeAll(function(){
+            jest.resetModules();
+            jest.unmock('PushNotificationIOS');
+
+            jest.mock('../component', function(){
+                let RNNotificationsComponent = require('../component/index.android');
+                RNNotificationsComponent.component.getInitialNotification = function() {
+                    return new Promise(function (resolve) {
+                        resolve(JSON.parse(mockAndroidNotification));
+                    });
+                };
+                return RNNotificationsComponent;
+            });
+
+            Index = require('../index');
+
+            mockNotification = mockAndroidNotification;
+        });
+
+        it('with no custom handler', testWithNoCustomHandler);
+
+        it('with custom handler', testWithCustomHandler);
+
+        it('with popInitialNotification configuration set to true', testWithPopInitialConfigurationTrue);
+    });
+
+
+});

--- a/index.js
+++ b/index.js
@@ -165,10 +165,14 @@ Notifications.localNotificationSchedule = function(details: Object) {
 			fireDate: details.date.toISOString(),
 			alertBody: details.message,
 			soundName: soundName,
-			applicationIconBadgeNumber: parseInt(details.number, 10),
 			userInfo: details.userInfo,
 			repeatInterval: details.repeatType
+		};
+
+		if(details.number) {
+			iosDetails.applicationIconBadgeNumber = parseInt(details.number, 10);
 		}
+
 		// ignore Android only repeatType
 		if (!details.repeatType || details.repeatType === 'time') {
 			delete iosDetails.repeatInterval;

--- a/index.js
+++ b/index.js
@@ -90,11 +90,7 @@ Notifications.configure = function(options: Object) {
 
 	if ( this.hasPoppedInitialNotification === false &&
 			( options.popInitialNotification === undefined || options.popInitialNotification === true ) ) {
-		this.popInitialNotification(function(firstNotification) {
-			if ( firstNotification !== null ) {
-				this._onNotification(firstNotification, true);
-			}
-		}.bind(this));
+		this.popInitialNotification();
 		this.hasPoppedInitialNotification = true;
 	}
 
@@ -298,7 +294,11 @@ Notifications.getApplicationIconBadgeNumber = function() {
 
 Notifications.popInitialNotification = function(handler) {
 	this.callNative('getInitialNotification').then(function(result){
-		handler(result);
+		if (handler) {
+			handler(result);
+		} else if ( result !== null ) {
+			this._onNotification(result, true);
+		}
 	});
 };
 

--- a/index.js
+++ b/index.js
@@ -90,6 +90,7 @@ Notifications.configure = function(options: Object) {
 
 	if ( this.hasPoppedInitialNotification === false &&
 			( options.popInitialNotification === undefined || options.popInitialNotification === true ) ) {
+		this.popInitialNotification = this.popInitialNotification.bind(this);
 		this.popInitialNotification();
 		this.hasPoppedInitialNotification = true;
 	}
@@ -299,7 +300,7 @@ Notifications.popInitialNotification = function(handler) {
 		} else if ( result !== null ) {
 			this._onNotification(result, true);
 		}
-	});
+	}.bind(this));
 };
 
 Notifications.abandonPermissions = function() {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React Native Local and Remote Notifications",
   "main": "index",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [
     "react-component",
@@ -32,5 +32,13 @@
     }
   },
   "author": "zo0r <http://zo0r.me>",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "babel-jest": "^20.0.3",
+    "jest": "^20.0.4",
+    "regenerator-runtime": "^0.10.5"
+  },
+  "jest": {
+    "preset": "react-native"
+  }
 }


### PR DESCRIPTION
I believe the popInitialNotification is used mainly to control the timing of when to handle the initial notification (this is the case in my app) but the handling itself is no different than any other notification.
The proposed solution maintains backwards compatibility for passing in a custom handler but will use the _onNotification if no handler is passed. 
I think in most cases where popInitialNotification is used with current implementation people either duplicate the code in _onNotification or use the private _onNotification as the handler for popInitialNotification.