### PR TITLE
Allow category of remote iOS notifications to be queried, if available

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,6 +222,7 @@ Notifications._onNotification = function(data, isFromBackground = null) {
 				data: data.getData(),
 				badge: data.getBadgeCount(),
 				alert: data.getAlert(),
+				category: (data.getCategory ? data.getCategory() : undefined),
 				sound: data.getSound()
 			});
 		} else {


### PR DESCRIPTION
Hi there,

This change is to allow the category field from iOS push notifications to be queried. To test it, I've replaced the version in an existing RN app of mine with this fix, sent a remote push notification, and been able to log out the contents of the category field in downstream app code.

This change is in anticipation of (and depends on) [a similar fix I've recently submitted for React Native](https://github.com/facebook/react-native/commit/dd8ed629a5ec2215e24b104dee45bef3fb08dc61). I've made it backward compatible so that it won't just fail for versions of RN which don't yet have the fix.

Many thanks,
James