### PR TITLE
Prevent from receive duplicated push notification

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,5 +42,5 @@ dependencies {
     compile 'com.android.support:appcompat-v7:23.1.1'
     compile 'com.facebook.react:react-native:+'
     compile 'com.google.android.gms:play-services-gcm:+'
-    compile 'me.leolin:ShortcutBadger:1.1.8@aar'
+    compile 'me.leolin:ShortcutBadger:1.1.+@aar'
 }

--- a/android/src/main/java/com/dieam/reactnativepushnotification/ReactNativePushNotificationPackage.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/ReactNativePushNotificationPackage.java
@@ -17,7 +17,7 @@ public class ReactNativePushNotificationPackage implements ReactPackage {
         return Collections.<NativeModule>singletonList(new RNPushNotification(reactContext));
     }
 
-    @Override
+    // Deprecated on RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
@@ -119,9 +119,12 @@ public class RNPushNotificationListenerService extends GcmListenerService {
         Log.v(LOG_TAG, "sendNotification: " + bundle);
 
         if (!isForeground) {
-            Application applicationContext = (Application) context.getApplicationContext();
-            RNPushNotificationHelper pushNotificationHelper = new RNPushNotificationHelper(applicationContext);
-            pushNotificationHelper.sendToNotificationCentre(bundle);
+            JSONObject data = getPushData(bundle.getString("data"));
+            if(data != null && (data.has("alert") || data.has("title"))) {
+                Application applicationContext = (Application) context.getApplicationContext();
+                RNPushNotificationHelper pushNotificationHelper = new RNPushNotificationHelper(applicationContext);
+                pushNotificationHelper.sendToNotificationCentre(bundle);
+            }
         }
     }
 

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
@@ -23,10 +23,19 @@ import java.util.Random;
 import static com.dieam.reactnativepushnotification.modules.RNPushNotification.LOG_TAG;
 
 public class RNPushNotificationListenerService extends GcmListenerService {
+    public static String previousPushId = "";
+    public static String currentPushId = "";
 
     @Override
     public void onMessageReceived(String from, final Bundle bundle) {
         JSONObject data = getPushData(bundle.getString("data"));
+
+        currentPushId = bundle.getString("push_id");
+        if(currentPushId.equals(previousPushId)){
+            Log.v(LOG_TAG, "Ignored duplicated push " + currentPushId);
+            return;
+        }
+
         if (data != null) {
             if (!bundle.containsKey("message")) {
                 bundle.putString("message", data.optString("alert", "Notification received"));
@@ -75,6 +84,8 @@ public class RNPushNotificationListenerService extends GcmListenerService {
                 }
             }
         });
+
+        previousPushId = currentPushId;
     }
 
     private JSONObject getPushData(String dataString) {


### PR DESCRIPTION
Sometimes user will receive multiple identical push notification due to install and uninstall app multiple times, thus this quick fix will prevent user from receive same PN.