### PR TITLE
Remove depreciated createJSModules marker - RN 0.47 compatibility

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/ReactNativePushNotificationPackage.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/ReactNativePushNotificationPackage.java
@@ -17,7 +17,6 @@ public class ReactNativePushNotificationPackage implements ReactPackage {
         return Collections.<NativeModule>singletonList(new RNPushNotification(reactContext));
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/dieam/reactnativepushnotification/ReactNativePushNotificationPackage.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/ReactNativePushNotificationPackage.java
@@ -17,7 +17,7 @@ public class ReactNativePushNotificationPackage implements ReactPackage {
         return Collections.<NativeModule>singletonList(new RNPushNotification(reactContext));
     }
 
-    // Depreciated RN 0.47
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/dieam/reactnativepushnotification/ReactNativePushNotificationPackage.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/ReactNativePushNotificationPackage.java
@@ -17,7 +17,7 @@ public class ReactNativePushNotificationPackage implements ReactPackage {
         return Collections.<NativeModule>singletonList(new RNPushNotification(reactContext));
     }
 
-    // Deprecated RN 0.47
+    // Depreciated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/dieam/reactnativepushnotification/ReactNativePushNotificationPackage.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/ReactNativePushNotificationPackage.java
@@ -17,6 +17,7 @@ public class ReactNativePushNotificationPackage implements ReactPackage {
         return Collections.<NativeModule>singletonList(new RNPushNotification(reactContext));
     }
 
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
[`createJSModules` is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from RN 0.47. I actually can't build an app on RN 0.47 without removing this method/ovveride marker. This is backwards compatible according to my tests.