### PR TITLE
Fix Android compilation error with RN 0.47

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/ReactNativePushNotificationPackage.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/ReactNativePushNotificationPackage.java
@@ -18,11 +18,6 @@ public class ReactNativePushNotificationPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Method createJSModules was removed from RN 0.47. Which leads to compilation error due to @Override annotation. This method can be removed right now.