### PR TITLE
Remove createJSModules @Override

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/ReactNativePushNotificationPackage.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/ReactNativePushNotificationPackage.java
@@ -17,7 +17,7 @@ public class ReactNativePushNotificationPackage implements ReactPackage {
         return Collections.<NativeModule>singletonList(new RNPushNotification(reactContext));
     }
 
-    @Override
+    // Deprecated in React Native 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
createJSModule was removed in React Native 0.47. By removing the override annotation this now compiles correctly again in all versions of React Native.