### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,17 @@ public class MainApplication extends Application implements ReactApplication {
 }
 ```
 
+If your app has an @Override on onNewIntent in `MainActivity.java` ensure that function includes a super call on onNewIntent (if your `MainActivity.java` does not have an @Override for onNewIntent skip this):
+
+```java
+    @Override
+    public void onNewIntent(Intent intent) {
+        ...
+        super.onNewIntent(intent);
+        ...
+    }
+```
+
 ## Usage
 ```javascript
 var PushNotification = require('react-native-push-notification');


### PR DESCRIPTION
Added info to help with a gotcha we encountered whilst using this package.  Lacking the super call meant that the extras from the notification were ignored.

We couldn't get onNotifications to fire on Android local scheduled notifications and we found that during an installation of another module, namely React Native Branch Deep Linking, onNewIntent was overridden without adding the super.onNewIntent() bit.  This and possibly other RN modules could be leading to some of the difficulties with onNotification not firing.