### PR TITLE
add initial notification property for IOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Notification object example:
 {
     foreground: false, // BOOLEAN: If the notification was received in foreground or not
     userInteraction: false, // BOOLEAN: If the notification was opened by the user from the notification area or not
+    initialNotification: false, // BOOLEAN: IOS only, if notification is from popInitialNotification
     message: 'My Notification Message', // STRING: The notification message
     data: {}, // OBJECT: The push data
 }

--- a/index.js
+++ b/index.js
@@ -205,19 +205,19 @@ Notifications._onRemoteFetch = function(notificationData: Object) {
 	}
 };
 
-Notifications._onNotification = function(data, isFromBackground = null) {
-	if ( isFromBackground === null ) {
-		isFromBackground = (
-			data.foreground === false ||
-			AppState.currentState === 'background'
-		);
-	}
+Notifications._onNotification = function(data, initialNotification = false) {
+    const isFromBackground = (
+    	initialNotification ||
+        data.foreground === false ||
+        AppState.currentState === 'background'
+    );
 
-	if ( this.onNotification !== false ) {
-		if ( Platform.OS === 'ios' ) {
-			this.onNotification({
-				foreground: ! isFromBackground,
-				userInteraction: isFromBackground,
+    if ( this.onNotification !== false ) {
+        if ( Platform.OS === 'ios' ) {
+            this.onNotification({
+                foreground: ! isFromBackground,
+                userInteraction: isFromBackground,
+                initialNotification: initialNotification,
 				message: data.getMessage(),
 				data: data.getData(),
 				badge: data.getBadgeCount(),


### PR DESCRIPTION
Was unable to determine that a IOS notification was from the popInitialNotification, so I added an IOS boolean property for initial notification.

The property initialNotification is set for IOS. Since this is a new property it should leave existing code unchanged.

To test this change, send a notification with the app closed. Tap the notification, which should start the app. The property initialNotification should be true.