### PR TITLE
android: check the drawable path for notifications icon

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -193,6 +193,10 @@ public class RNPushNotificationHelper {
                 smallIconResId = res.getIdentifier(smallIcon, "mipmap", packageName);
             } else {
                 smallIconResId = res.getIdentifier("ic_notification", "mipmap", packageName);
+
+                if (smallIconResId == 0) {
+                    smallIconResId = res.getIdentifier("ic_notification", "drawable", packageName);
+                }
             }
 
             if (smallIconResId == 0) {


### PR DESCRIPTION
because it is a default one if icons were created by the Android Studio "New" -> "Image asset"