### PR TITLE
Make local notifications on android notify the application too

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
@@ -97,7 +97,6 @@ public class RNPushNotificationListenerService extends GcmListenerService {
 
         RNPushNotificationJsDelivery jsDelivery = new RNPushNotificationJsDelivery(context);
         bundle.putBoolean("foreground", isForeground);
-        bundle.putBoolean("userInteraction", false);
         jsDelivery.notifyNotification(bundle);
 
         // If contentAvailable is set to true, then send out a remote fetch event

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
@@ -56,7 +56,7 @@ public class RNPushNotificationListenerService extends GcmListenerService {
         handler.post(new Runnable() {
             public void run() {
                 // Construct and load our normal React JS code bundle
-                ReactInstanceManager mReactInstanceManager = ((ReactApplication) getApplication()).getReactNativeHost().getReactInstanceManager();
+                final ReactInstanceManager mReactInstanceManager = ((ReactApplication) getApplication()).getReactNativeHost().getReactInstanceManager();
                 ReactContext context = mReactInstanceManager.getCurrentReactContext();
                 // If it's constructed, send a notification
                 if (context != null) {
@@ -66,6 +66,7 @@ public class RNPushNotificationListenerService extends GcmListenerService {
                     mReactInstanceManager.addReactInstanceEventListener(new ReactInstanceManager.ReactInstanceEventListener() {
                         public void onReactContextInitialized(ReactContext context) {
                             handleRemotePushNotification((ReactApplicationContext) context, bundle);
+                            mReactInstanceManager.removeReactInstanceEventListener(this);
                         }
                     });
                     if (!mReactInstanceManager.hasStartedCreatingInitialContext()) {

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationPublisher.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationPublisher.java
@@ -107,7 +107,6 @@ public class RNPushNotificationPublisher extends BroadcastReceiver {
 
         RNPushNotificationJsDelivery jsDelivery = new RNPushNotificationJsDelivery(context);
         bundle.putBoolean("foreground", isForeground);
-        bundle.putBoolean("userInteraction", false);
         jsDelivery.notifyNotification(bundle);
 
         // If contentAvailable is set to true, then send out a remote fetch event

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationPublisher.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationPublisher.java
@@ -36,27 +36,6 @@ public class RNPushNotificationPublisher extends BroadcastReceiver {
 
         final Bundle bundle = intent.getExtras();
 
-        JSONObject data = getPushData(bundle.getString("data"));
-        if (data != null) {
-            if (!bundle.containsKey("message")) {
-                bundle.putString("message", data.optString("alert", "Notification received"));
-            }
-            if (!bundle.containsKey("title")) {
-                bundle.putString("title", data.optString("title", null));
-            }
-            if (!bundle.containsKey("sound")) {
-                bundle.putString("soundName", data.optString("sound", null));
-            }
-            if (!bundle.containsKey("color")) {
-                bundle.putString("color", data.optString("color", null));
-            }
-
-            final int badge = data.optInt("badge", -1);
-            if (badge >= 0) {
-                ApplicationBadgeHelper.INSTANCE.setApplicationIconBadgeNumber(context, badge);
-            }
-        }
-
         Log.v(LOG_TAG, "onMessageReceived: " + bundle);
 
         // We need to run this on the main thread, as the React code assumes that is true.
@@ -66,7 +45,7 @@ public class RNPushNotificationPublisher extends BroadcastReceiver {
         handler.post(new Runnable() {
             public void run() {
                 // Construct and load our normal React JS code bundle
-                ReactInstanceManager mReactInstanceManager = ((ReactApplication) context.getApplicationContext()).getReactNativeHost().getReactInstanceManager();
+                final ReactInstanceManager mReactInstanceManager = ((ReactApplication) context.getApplicationContext()).getReactNativeHost().getReactInstanceManager();
                 ReactContext context = mReactInstanceManager.getCurrentReactContext();
                 // If it's constructed, send a notification
                 if (context != null) {
@@ -76,6 +55,7 @@ public class RNPushNotificationPublisher extends BroadcastReceiver {
                     mReactInstanceManager.addReactInstanceEventListener(new ReactInstanceManager.ReactInstanceEventListener() {
                         public void onReactContextInitialized(ReactContext context) {
                             handleLocalNotification((ReactApplicationContext) context, bundle);
+                            mReactInstanceManager.removeReactInstanceEventListener(this);
                         }
                     });
                     if (!mReactInstanceManager.hasStartedCreatingInitialContext()) {
@@ -85,14 +65,6 @@ public class RNPushNotificationPublisher extends BroadcastReceiver {
                 }
             }
         });
-    }
-
-    private JSONObject getPushData(String dataString) {
-        try {
-            return new JSONObject(dataString);
-        } catch (Exception e) {
-            return null;
-        }
     }
 
     private void handleLocalNotification(ReactApplicationContext context, Bundle bundle) {

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationPublisher.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationPublisher.java
@@ -1,14 +1,11 @@
 package com.dieam.reactnativepushnotification.modules;
 
+import android.app.ActivityManager;
+import android.app.ActivityManager.RunningAppProcessInfo;
 import android.app.Application;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.util.Log;
-
-import android.app.ActivityManager;
-import android.app.ActivityManager.RunningAppProcessInfo;
-import android.app.Application;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -19,7 +16,6 @@ import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
-import com.google.android.gms.gcm.GcmListenerService;
 
 import org.json.JSONObject;
 

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationPublisher.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationPublisher.java
@@ -6,21 +6,143 @@ import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
 
+import android.app.ActivityManager;
+import android.app.ActivityManager.RunningAppProcessInfo;
+import android.app.Application;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+
+import com.dieam.reactnativepushnotification.helpers.ApplicationBadgeHelper;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
+import com.google.android.gms.gcm.GcmListenerService;
+
+import org.json.JSONObject;
+
+import java.util.List;
+import java.util.Random;
+
 import static com.dieam.reactnativepushnotification.modules.RNPushNotification.LOG_TAG;
 
 public class RNPushNotificationPublisher extends BroadcastReceiver {
     final static String NOTIFICATION_ID = "notificationId";
 
     @Override
-    public void onReceive(Context context, Intent intent) {
+    public void onReceive(final Context context, Intent intent) {
         int id = intent.getIntExtra(NOTIFICATION_ID, 0);
         long currentTime = System.currentTimeMillis();
 
         Log.i(LOG_TAG, "NotificationPublisher: Prepare To Publish: " + id + ", Now Time: " + currentTime);
 
-        Application applicationContext = (Application) context.getApplicationContext();
+        final Bundle bundle = intent.getExtras();
 
-        new RNPushNotificationHelper(applicationContext)
-                .sendToNotificationCentre(intent.getExtras());
+        JSONObject data = getPushData(bundle.getString("data"));
+        if (data != null) {
+            if (!bundle.containsKey("message")) {
+                bundle.putString("message", data.optString("alert", "Notification received"));
+            }
+            if (!bundle.containsKey("title")) {
+                bundle.putString("title", data.optString("title", null));
+            }
+            if (!bundle.containsKey("sound")) {
+                bundle.putString("soundName", data.optString("sound", null));
+            }
+            if (!bundle.containsKey("color")) {
+                bundle.putString("color", data.optString("color", null));
+            }
+
+            final int badge = data.optInt("badge", -1);
+            if (badge >= 0) {
+                ApplicationBadgeHelper.INSTANCE.setApplicationIconBadgeNumber(context, badge);
+            }
+        }
+
+        Log.v(LOG_TAG, "onMessageReceived: " + bundle);
+
+        // We need to run this on the main thread, as the React code assumes that is true.
+        // Namely, DevServerHelper constructs a Handler() without a Looper, which triggers:
+        // "Can't create handler inside thread that has not called Looper.prepare()"
+        Handler handler = new Handler(Looper.getMainLooper());
+        handler.post(new Runnable() {
+            public void run() {
+                // Construct and load our normal React JS code bundle
+                ReactInstanceManager mReactInstanceManager = ((ReactApplication) context.getApplicationContext()).getReactNativeHost().getReactInstanceManager();
+                ReactContext context = mReactInstanceManager.getCurrentReactContext();
+                // If it's constructed, send a notification
+                if (context != null) {
+                    handleLocalNotification((ReactApplicationContext) context, bundle);
+                } else {
+                    // Otherwise wait for construction, then send the notification
+                    mReactInstanceManager.addReactInstanceEventListener(new ReactInstanceManager.ReactInstanceEventListener() {
+                        public void onReactContextInitialized(ReactContext context) {
+                            handleLocalNotification((ReactApplicationContext) context, bundle);
+                        }
+                    });
+                    if (!mReactInstanceManager.hasStartedCreatingInitialContext()) {
+                        // Construct it in the background
+                        mReactInstanceManager.createReactContextInBackground();
+                    }
+                }
+            }
+        });
+    }
+
+    private JSONObject getPushData(String dataString) {
+        try {
+            return new JSONObject(dataString);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private void handleLocalNotification(ReactApplicationContext context, Bundle bundle) {
+
+        // If notification ID is not provided by the user for push notification, generate one at random
+        if (bundle.getString("id") == null) {
+            Random randomNumberGenerator = new Random(System.currentTimeMillis());
+            bundle.putString("id", String.valueOf(randomNumberGenerator.nextInt()));
+        }
+
+        Boolean isForeground = isApplicationInForeground(context);
+
+        RNPushNotificationJsDelivery jsDelivery = new RNPushNotificationJsDelivery(context);
+        bundle.putBoolean("foreground", isForeground);
+        bundle.putBoolean("userInteraction", false);
+        jsDelivery.notifyNotification(bundle);
+
+        // If contentAvailable is set to true, then send out a remote fetch event
+        if (bundle.getString("contentAvailable", "false").equalsIgnoreCase("true")) {
+            jsDelivery.notifyRemoteFetch(bundle);
+        }
+
+        Log.v(LOG_TAG, "sendNotification: " + bundle);
+
+        if (!isForeground) {
+            Application applicationContext = (Application) context.getApplicationContext();
+            RNPushNotificationHelper pushNotificationHelper = new RNPushNotificationHelper(applicationContext);
+            pushNotificationHelper.sendToNotificationCentre(bundle);
+        }
+    }
+
+    private boolean isApplicationInForeground(ReactApplicationContext context) {
+        ActivityManager activityManager = (ActivityManager) context.getSystemService(context.ACTIVITY_SERVICE);
+        List<RunningAppProcessInfo> processInfos = activityManager.getRunningAppProcesses();
+        if (processInfos != null) {
+            for (RunningAppProcessInfo processInfo : processInfos) {
+            Application applicationContext = (Application) context.getApplicationContext();
+                if (processInfo.processName.equals(applicationContext.getPackageName())) {
+                    if (processInfo.importance == RunningAppProcessInfo.IMPORTANCE_FOREGROUND) {
+                        for (String d : processInfo.pkgList) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
RNPushNotificationPublisher receives the local notifications, but it doesn't route them to the application if it's in the foreground like the ListenerService does.  This makes it work the same for both, and thus duplicates the behavior that we see on iOS.

Also, I missed it when I first set up the code, but it appeared that userInteraction was overridden to false in the code, but I removed that so we can know if we were clicked from the notification center.

Hey, for people trying to handle background notifications on Android, the intent filter trick listed in [122](https://github.com/zo0r/react-native-push-notification/issues/122) worked for me.

I can now receive local notifications in the foreground and background, warm and cold start on iOS and Android and onNotification is called.