### PR TITLE
Add nullchecks for JSON parsing

### DIFF
--- a/component/index.android.js
+++ b/component/index.android.js
@@ -67,8 +67,10 @@ NotificationsComponent.prototype.addEventListener = function(type: string, handl
 		listener =  DeviceEventEmitter.addListener(
 			DEVICE_NOTIF_EVENT,
 			function(notifData) {
-				var data = JSON.parse(notifData.dataJSON);
-				handler(data);
+				if (notifData && notifData.dataJSON) {
+					var data = JSON.parse(notifData.dataJSON);
+					handler(data);
+				}
 			}
 		);
 	} else if (type === 'register') {
@@ -82,8 +84,10 @@ NotificationsComponent.prototype.addEventListener = function(type: string, handl
 		listener = DeviceEventEmitter.addListener(
 			REMOTE_FETCH_EVENT,
 			function(notifData) {
-				var notificationData = JSON.parse(notifData.dataJSON)
-				handler(notificationData);
+				if (notifData && notifData.dataJSON) {
+					var notificationData = JSON.parse(notifData.dataJSON)
+					handler(notificationData);
+				}
 			}
 		);
 	}


### PR DESCRIPTION
I had a crash due to a conflict with the `react-native-onesignal` package.
Push coming from OneSignal were handled in the `react-native-push-notification` code but the format is not the same.