### PR TITLE
Add support for notification alert title on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ PushNotification.localNotification({
     userInfo: // (optional) default: null (object containing additional notification data)
 
     /* iOS and Android properties */
-    title: "My Notification Title", // (optional, for iOS this is only used in apple watch, the title will be the app name on other iOS devices)
+    title: "My Notification Title", // (optional)
     message: "My Notification Message", // (required)
     playSound: false, // (optional) default: true
     soundName: 'default', // (optional) Sound to play when the notification is shown. Value of 'default' plays the default sound. It can be set to a custom sound such as 'android.resource://com.xyz/raw/my_sound'. It will look for the 'my_sound' audio file in 'res/raw' directory and play it. default: 'default' (default sound is played)

--- a/index.js
+++ b/index.js
@@ -116,8 +116,8 @@ Notifications.unregister = function() {
 /**
  * Local Notifications
  * @param {Object}		details
+ * @param {String}		details.title  -  The title displayed in the notification alert.
  * @param {String}		details.message - The message displayed in the notification alert.
- * @param {String}		details.title  -  ANDROID ONLY: The title displayed in the notification alert.
  * @param {String}		details.ticker -  ANDROID ONLY: The ticker displayed in the status bar.
  * @param {Object}		details.userInfo -  iOS ONLY: The userInfo used in the notification alert.
  */
@@ -163,6 +163,7 @@ Notifications.localNotificationSchedule = function(details: Object) {
 
 		const iosDetails = {
 			fireDate: details.date.toISOString(),
+			alertTitle: details.title,
 			alertBody: details.message,
 			soundName: soundName,
 			userInfo: details.userInfo,


### PR DESCRIPTION
React Native added support for the alert title some time ago.
It can be seen in this commit: https://github.com/facebook/react-native/commit/ec74a9696a8864928cab59e40db8b446deb23762#diff-2809d4592d87587e30e146d50d49188d
This closes #608