### PR TITLE
DOC - make explicit that senderID is project Id

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ PushNotification.configure({
     },
 
     // ANDROID ONLY: GCM Sender ID (optional - not required for local notifications, but is need to receive remote push notifications)
+    // GCM/FCM Sender ID is your project Id and NOT your API Key
     senderID: "YOUR GCM SENDER ID",
 
     // IOS ONLY (optional): default: all - Permissions to register.


### PR DESCRIPTION
It was a key for me to understand that senderID was not an API Key. As no error message popup when senderID is incorrect, I believe its important to say it explicitly in docs.