### PR TITLE
Improve notification action handling on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ PushNotification.localNotification({
     tag: 'some_tag', // (optional) add tag to message
     group: "group", // (optional) add group to message
     ongoing: false, // (optional) set whether this is an "ongoing" notification
+    actions: [{id: “actionId”, text: “Display Text”}],  // (optional) See the doc for notification actions to know more
 
     /* iOS only properties */
     alertAction: // (optional) default: view
@@ -215,7 +216,6 @@ PushNotification.localNotification({
     soundName: 'default', // (optional) Sound to play when the notification is shown. Value of 'default' plays the default sound. It can be set to a custom sound such as 'android.resource://com.xyz/raw/my_sound'. It will look for the 'my_sound' audio file in 'res/raw' directory and play it. default: 'default' (default sound is played)
     number: '10', // (optional) Valid 32 bit integer specified as string. default: none (Cannot be zero)
     repeatType: 'day', // (Android only) Repeating interval. Could be one of `week`, `day`, `hour`, `minute, `time`. If specified as time, it should be accompanied by one more parameter 'repeatTime` which should the number of milliseconds between each interval
-    actions: '["Yes", "No"]',  // (Android only) See the doc for notification actions to know more
 });
 ```
 
@@ -270,16 +270,14 @@ For iOS, the repeating notification should land soon. It has already been merged
 
 ## Notification Actions ##
 
-(Android only) [Refer](https://github.com/zo0r/react-native-push-notification/issues/151) to this issue to see an example of a notification action.
-
 Two things are required to setup notification actions.
 
 ### 1) Specify notification actions for a notification
-This is done by specifying an `actions` parameters while configuring the local notification. This is an array of strings where each string is a notificaiton action that will be presented with the notification.
+This is done by specifying an `actions` parameters while configuring the local notification. This is an array of objects. Each object represent on action button on notification and each should contain two properties:
+1. `id` - unique action identifier for Android Intent. It will be prefixed by application package name, so you don’t need to provide it here,
+2. `text` - Human readable (and localized) text that will appear on the button.
 
-For e.g. `actions: '["Accept", "Reject"]'  // Must be in string format`
-
-The array itself is specified in string format to circumvent some problems because of the way JSON arrays are handled by react-native android bridge.
+For e.g. `actions: [{id: “firstAction”, text: “Mark as Done”}]
 
 ### 2) Specify handlers for the notification actions
 For each action specified in the `actions` field, we need to add a handler that is called when the user clicks on the action. This can be done in the `componentWillMount` of your main app file or in a separate file which is imported in your main app file. Notification actions handlers can be configured as below:
@@ -289,13 +287,13 @@ import PushNotificationAndroid from 'react-native-push-notification'
 
 (function() {
   // Register all the valid actions for notifications here and add the action handler for each action
-  PushNotificationAndroid.registerNotificationActions(['Accept','Reject','Yes','No']);
+  PushNotificationAndroid.registerNotificationActions(['firstAction','secondAction']); // here provide action id’s from previous step
   DeviceEventEmitter.addListener('notificationActionReceived', function(action){
     console.log ('Notification action received: ' + action);
     const info = JSON.parse(action.dataJSON);
-    if (info.action == 'Accept') {
+    if (info.action == 'firstAction') {
       // Do work pertaining to Accept action here
-    } else if (info.action == 'Reject') {
+    } else if (info.action == 'secondAction') {
       // Do work pertaining to Reject action here
     }
     // Add all the required actions handlers

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,12 +16,12 @@ allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 23
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         ndk {
@@ -39,7 +39,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'com.android.support:appcompat-v7:26.0.+'
     compile 'com.facebook.react:react-native:+'
     compile 'com.google.android.gms:play-services-gcm:+'
     compile 'me.leolin:ShortcutBadger:1.1.8@aar'

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -82,29 +82,6 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
         }, intentFilter);
     }
 
-    private void registerNotificationsReceiveNotificationActions(ReadableArray actions) {
-        IntentFilter intentFilter = new IntentFilter();
-        // Add filter for each actions.
-        for (int i = 0; i < actions.size(); i++) {
-            String action = actions.getString(i);
-            intentFilter.addAction(getReactApplicationContext().getPackageName() + "." + action);
-        }
-        getReactApplicationContext().registerReceiver(new BroadcastReceiver() {
-            @Override
-            public void onReceive(Context context, Intent intent) {
-                Bundle bundle = intent.getBundleExtra("notification");
-
-                // Notify the action.
-                mJsDelivery.notifyNotificationAction(bundle);
-
-                // Dismiss the notification popup.
-                NotificationManager manager = (NotificationManager) context.getSystemService(context.NOTIFICATION_SERVICE);
-                int notificationID = Integer.parseInt(bundle.getString("id"));
-                manager.cancel(notificationID);
-            }
-        }, intentFilter);
-    }
-
     @ReactMethod
     public void requestPermissions(String senderID) {
         ReactContext reactContext = getReactApplicationContext();
@@ -192,10 +169,5 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
      */
     public void cancelLocalNotifications(ReadableMap userInfo) {
         mRNPushNotificationHelper.cancelScheduledNotification(userInfo);
-    }
-
-    @ReactMethod
-    public void registerNotificationActions(ReadableArray actions) {
-        registerNotificationsReceiveNotificationActions(actions);
     }
 }

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationActionHandlerReceiver.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationActionHandlerReceiver.java
@@ -1,0 +1,54 @@
+package com.dieam.reactnativepushnotification.modules;
+
+import android.app.ActivityManager;
+import android.app.NotificationManager;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+
+import com.facebook.react.HeadlessJsTaskService;
+
+import java.util.List;
+
+public class RNPushNotificationActionHandlerReceiver extends BroadcastReceiver {
+
+  @Override
+  public void onReceive(Context context, Intent intent) {
+    Intent serviceIntent = new Intent(context, RNPushNotificationActionService.class);
+    serviceIntent.putExtras(intent.getExtras());
+    context.startService(serviceIntent);
+
+    // Dismiss the notification popup.
+    Bundle bundle = intent.getBundleExtra("notification");
+    NotificationManager manager = (NotificationManager) context.getSystemService(context.NOTIFICATION_SERVICE);
+    int notificationID = Integer.parseInt(bundle.getString("id"));
+    manager.cancel(notificationID);
+
+    if (!isAppOnForeground((context))) {
+      HeadlessJsTaskService.acquireWakeLockNow(context);
+    }
+  }
+
+  private boolean isAppOnForeground(Context context) {
+    /**
+     We need to check if app is in foreground otherwise the app will crash.
+     http://stackoverflow.com/questions/8489993/check-android-application-is-in-foreground-or-not
+     **/
+    ActivityManager activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+    List<ActivityManager.RunningAppProcessInfo> appProcesses =
+        activityManager.getRunningAppProcesses();
+    if (appProcesses == null) {
+      return false;
+    }
+    final String packageName = context.getPackageName();
+    for (ActivityManager.RunningAppProcessInfo appProcess : appProcesses) {
+      if (appProcess.importance ==
+          ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND &&
+          appProcess.processName.equals(packageName)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationActionHandlerReceiver.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationActionHandlerReceiver.java
@@ -15,6 +15,9 @@ public class RNPushNotificationActionHandlerReceiver extends BroadcastReceiver {
 
   @Override
   public void onReceive(Context context, Intent intent) {
+    if (intent == null || intent.getExtras() == null) {
+      return;
+    }
     Intent serviceIntent = new Intent(context, RNPushNotificationActionService.class);
     serviceIntent.putExtras(intent.getExtras());
     context.startService(serviceIntent);

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationActionService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationActionService.java
@@ -1,0 +1,22 @@
+package com.dieam.reactnativepushnotification.modules;
+
+import android.content.Intent;
+
+import com.facebook.react.HeadlessJsTaskService;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.jstasks.HeadlessJsTaskConfig;
+
+import javax.annotation.Nullable;
+
+public class RNPushNotificationActionService extends HeadlessJsTaskService {
+  @Nullable
+  @Override
+  protected HeadlessJsTaskConfig getTaskConfig(Intent intent) {
+    return new HeadlessJsTaskConfig(
+        "RNPushNotificationActionHandlerTask",
+        Arguments.fromBundle(intent.getExtras()),
+        5000,
+        true
+    );
+  }
+}

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -4,6 +4,7 @@ package com.dieam.reactnativepushnotification.modules;
 import android.app.AlarmManager;
 import android.app.Application;
 import android.app.Notification;
+import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
@@ -36,6 +37,7 @@ import static com.dieam.reactnativepushnotification.modules.RNPushNotificationAt
 public class RNPushNotificationHelper {
     public static final String PREFERENCES_KEY = "rn_push_notification";
     private static final long DEFAULT_VIBRATION = 300L;
+    private static final String NOTIFICATION_CHANNEL_ID = "rn-push-notification-channel-id";
 
     private Context context;
     private final SharedPreferences scheduledNotificationsPersistence;
@@ -159,7 +161,7 @@ public class RNPushNotificationHelper {
                 title = context.getPackageManager().getApplicationLabel(appInfo).toString();
             }
 
-            NotificationCompat.Builder notification = new NotificationCompat.Builder(context)
+            NotificationCompat.Builder notification = new NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ID)
                     .setContentTitle(title)
                     .setTicker(bundle.getString("ticker"))
                     .setVisibility(NotificationCompat.VISIBILITY_PRIVATE)
@@ -274,6 +276,7 @@ public class RNPushNotificationHelper {
                     PendingIntent.FLAG_UPDATE_CURRENT);
 
             NotificationManager notificationManager = notificationManager();
+            checkOrCreateChannel(notificationManager);
 
             notification.setContentIntent(pendingIntent);
 
@@ -455,5 +458,24 @@ public class RNPushNotificationHelper {
         } else {
             editor.apply();
         }
+    }
+
+    private static boolean channelCreated = false;
+    private static void checkOrCreateChannel(NotificationManager manager) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
+            return;
+        if (channelCreated)
+            return;
+        if (manager == null)
+            return;
+
+        final CharSequence name = "rn-push-notification-channel";
+        int importance = NotificationManager.IMPORTANCE_DEFAULT;
+        NotificationChannel channel = new NotificationChannel(NOTIFICATION_CHANNEL_ID, name, importance);
+        channel.enableLights(true);
+        channel.enableVibration(true);
+
+        manager.createNotificationChannel(channel);
+        channelCreated = true;
     }
 }

--- a/component/index.android.js
+++ b/component/index.android.js
@@ -100,10 +100,6 @@ NotificationsComponent.prototype.removeEventListener = function(type: string, ha
 	_notifHandlers.delete(type);
 }
 
-NotificationsComponent.prototype.registerNotificationActions = function(details: Object) {
-	RNPushNotification.registerNotificationActions(details);
-}
-
 NotificationsComponent.prototype.clearAllNotifications = function() {
 	RNPushNotification.clearAllNotifications()
 }

--- a/index.js
+++ b/index.js
@@ -313,10 +313,6 @@ Notifications.checkPermissions = function() {
 	return this.callNative('checkPermissions', arguments);
 };
 
-Notifications.registerNotificationActions = function() {
-	return this.callNative('registerNotificationActions', arguments)
-}
-
 Notifications.clearAllNotifications = function() {
 	// Only available for Android
 	return this.callNative('clearAllNotifications', arguments)


### PR DESCRIPTION
Improves integration with Android's notifications actions. Changes type of `action` property from `string` to `array` of `object`s. Also adds `id` property to each action, this way it splits action name (that can be internationalized) from the intent name.

Further more it moves `BroadcastReveiver` configuration to app's `AndroidManifest.xml` file. This fixes https://github.com/zo0r/react-native-push-notification/issues/626 where notification actions were not working (since there were no receiver registered) when app was not running.

Also updates README.md file and describes how to implement notification action support on android. 