### PR TITLE
Implement removeAllDeliveredNotifications.

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -183,6 +183,16 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
 
     @ReactMethod
     /**
+     * Remove all delivered notifications from Notification Center
+     *
+     * @see <a href="https://facebook.github.io/react-native/docs/pushnotificationios.html#removealldeliverednotifications">RN docs</a>
+     */
+    public void removeAllDeliveredNotifications() {
+        mRNPushNotificationHelper.clearNotifications();
+    }
+
+    @ReactMethod
+    /**
      * Cancel scheduled notifications, and removes notifications from the notification centre.
      *
      * Note - as we are trying to achieve feature parity with iOS, this method cannot be used

--- a/component/index.android.js
+++ b/component/index.android.js
@@ -38,6 +38,10 @@ NotificationsComponent.prototype.cancelAllLocalNotifications = function() {
 	RNPushNotification.cancelAllLocalNotifications();
 };
 
+NotificationsComponent.prototype.removeAllDeliveredNotifications = function() {
+	RNPushNotification.removeAllDeliveredNotifications();
+};
+
 NotificationsComponent.prototype.presentLocalNotification = function(details: Object) {
 	RNPushNotification.presentLocalNotification(details);
 };

--- a/index.js
+++ b/index.js
@@ -290,6 +290,10 @@ Notifications.cancelAllLocalNotifications = function() {
 	return this.callNative('cancelAllLocalNotifications', arguments);
 };
 
+Notifications.removeAllDeliveredNotifications = function() {
+	return this.callNative('removeAllDeliveredNotifications', arguments);
+};
+
 Notifications.setApplicationIconBadgeNumber = function() {
 	return this.callNative('setApplicationIconBadgeNumber', arguments);
 };


### PR DESCRIPTION
This function clears delivered notifications, but not scheduled local notifications.  Since it's in react-native's PushNotificationIOS, adding it to react-native-push-notification brings us closer to feature parity.  And this is a simple, but important one.  See [RN Docs](https://facebook.github.io/react-native/docs/pushnotificationios.html#removealldeliverednotifications).

The following code can be used to test this functionality:

```javascript
import {
  AppState,
} from "react-native";

import PushNotification from "react-native-push-notification";

function clearNotifications() {
  const { currentState } = AppState;

  if (currentState === "active") {
    PushNotification.removeAllDeliveredNotifications();
  }
}

AppState.addEventListener("change", clearNotifications);
setTimeout(clearNotifications, 0);
```

This makes notifications clear on startup and when the app enters foreground.  When you open the app, all notifications for the app in the notification center should disappear.  To further test it, schedule a notification, then put the app in the background and then the foreground again.  The scheduled notification should appear anyway.  Canceling scheduled local notifications was a blocker for my app before this PR.

This PR addresses one point in #427. I may implement the other new features if I find a need for them.