### PR TITLE
Fix id in present/scheduleLocalNotification.

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -119,8 +119,11 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
     public void presentLocalNotification(ReadableMap details) {
         Bundle bundle = Arguments.toBundle(details);
         // If notification ID is not provided by the user, generate one at random
-        if (bundle.getString("id") == null) {
+        double id = bundle.getDouble("id");
+        if (id == 0) {
             bundle.putString("id", String.valueOf(mRandomNumberGenerator.nextInt()));
+        } else {
+            bundle.putString("id", String.valueOf((int) id));
         }
         mRNPushNotificationHelper.sendToNotificationCentre(bundle);
     }
@@ -129,8 +132,11 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
     public void scheduleLocalNotification(ReadableMap details) {
         Bundle bundle = Arguments.toBundle(details);
         // If notification ID is not provided by the user, generate one at random
-        if (bundle.getString("id") == null) {
+        double id = bundle.getDouble("id");
+        if (id == 0) {
             bundle.putString("id", String.valueOf(mRandomNumberGenerator.nextInt()));
+        } else {
+            bundle.putString("id", String.valueOf((int) id));
         }
         mRNPushNotificationHelper.sendNotificationScheduled(bundle);
     }


### PR DESCRIPTION
In the docs it says you can provide a notificationId in `scheduleLocalNotification` like this:

```javascript
PushNotification.scheduleLocalNotification({
  id: Math.floor(2147483648*Math.random()),
  ...
});
```

but this doesn't work and a random ID is always generated by `react-native-push-notification` since it's read from the arguments bundle incorrectly.

I don't think this is a breaking change since trying to specify an `id` as a string causes a crash anyway.