### PR TITLE
Google play services versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ dependencies {
 }
 ```
 
-OR set the play-service-gcm version by setting a root project ext variable, `googlePlayServicesVersion`, to the version in your project.
+**OR** set the play-service-gcm version by setting a root project ext variable, `googlePlayServicesVersion`, to the version in your project.
 This is useful if you need to apply plugin 'com.google.gms.google-services' in app-build.gradle for other google play services in your project.
+
 project-build.gradle
 ```gradle
 ...

--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ dependencies {
 }
 ```
 
+OR set the play-service-gcm version by setting a root project ext variable, `googlePlayServicesVersion`, to the version in your project.
+This is useful if you need to apply plugin 'com.google.gms.google-services' in app-build.gradle for other google play services in your project.
+project-build.gradle
+```gradle
+...
+  ext {
+    // dependency versions
+    googlePlayServicesVersion = "11.8.0"
+}
+...
+```
+
+
 In your `AndroidManifest.xml`
 ```xml
     .....

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,10 +37,12 @@ android {
 }
 
 dependencies {
+    def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : "+"
+
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:23.1.1'
     compile 'com.facebook.react:react-native:+'
-    compile 'com.google.android.gms:play-services-gcm:+'
+    compile "com.google.android.gms:play-services-gcm:$googlePlayServicesVersion"
     compile 'me.leolin:ShortcutBadger:1.1.8@aar'
 }


### PR DESCRIPTION
 * Gradle fails to build with other modules requiring "apply plugin: 'com.google.gms.google-services'" in app-gradle.build. ie: FCM.

The error given is:
```gradle
Gradle sync failed: For input string: "+"
```

 * The change in this request adds the ability for a developer to pass in a version through a root project ext variable, `googlePlayServicesVersion`.

 * This change adds functionality to the Gradle build and is not operating system specific.

 * This change can be tested by adding FCM support to a project and then adding the apply plugin.
app-gradle.build

```gradle
...
dependencies {
    ...
    implementation project(':react-native-push-notification')
    implementation "com.google.firebase:firebase-core:$googlePlayServicesVersion"
    implementation "com.google.firebase:firebase-messaging:$googlePlayServicesVersion"
    ...
}
apply plugin: 'com.google.gms.google-services'
...
```