### PR TITLE
allow custom setup of notification action via custom category

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,6 +41,6 @@ dependencies {
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:23.1.1'
     compile 'com.facebook.react:react-native:+'
-    compile 'com.google.android.gms:play-services-gcm:+'
+    compile 'com.google.android.gms:play-services-gcm:16.1.0'
     compile 'me.leolin:ShortcutBadger:1.1.8@aar'
 }


### PR DESCRIPTION
My proposition on providing an ability to set custom activity as receiver of notification data.
takes care of
https://github.com/zo0r/react-native-push-notification/issues/183
and
https://github.com/zo0r/react-native-push-notification/issues/122

Safe with ShortcutBadger. the hack proposed at #122 crashes experia when combined with attempting to set the badger.

To mark a custom activity that should get notifications use this intent filter:

```
            <intent-filter android:label="notification_react_native">
                <action android:name="android.intent.action.MAIN" />
                <category android:name="com.dieam.reactnativepushnotification.intent.category.NOTIFY" />
            </intent-filter>
```
