### PR TITLE
[Android] Remove default alert for silent push notifications

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
@@ -29,7 +29,7 @@ public class RNPushNotificationListenerService extends GcmListenerService {
         JSONObject data = getPushData(bundle.getString("data"));
         if (data != null) {
             if (!bundle.containsKey("message")) {
-                bundle.putString("message", data.optString("alert", "Notification received"));
+                bundle.putString("message", data.optString("alert", null));
             }
             if (!bundle.containsKey("title")) {
                 bundle.putString("title", data.optString("title", null));


### PR DESCRIPTION
On Android silent push notifications trigger alert with `Notification received` message when app is in background.

If there is no `message` supplied then user should not be alerted with a default message. Otherwise it makes silent push notifications impossible on Android.

At the moment every time a silent push notification is received (while app is in background) user receives an alert with `Notification received` message.

Fixes: https://github.com/zo0r/react-native-push-notification/issues/410