### PR TITLE
Update README for FCM

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,29 @@ In your `AndroidManifest.xml`
 
 ```
 
+If you are using FCM instead of GCM, you should [remove the following lines](https://developers.google.com/cloud-messaging/android/android-migrate-fcm#edit-your-apps-manifest) to avoid receiving notifications both from GCM and FCM.
+
+```diff
+-    <uses-permission android:name="android.permission.WAKE_LOCK" />
+-    <permission
+-        android:name="${applicationId}.permission.C2D_MESSAGE"
+-        android:protectionLevel="signature" />
+-    <uses-permission android:name="${applicationId}.permission.C2D_MESSAGE" />
+
+...
+
+-        <receiver
+-            android:name="com.google.android.gms.gcm.GcmReceiver"
+-            android:exported="true"
+-            android:permission="com.google.android.c2dm.permission.SEND" >
+-            <intent-filter>
+-                <action android:name="com.google.android.c2dm.intent.RECEIVE" />
+-                <category android:name="${applicationId}" />
+-            </intent-filter>
+-        </receiver>
+```
+
+
 In `android/settings.gradle`
 ```gradle
 ...


### PR DESCRIPTION
Hello, 

When using FCM instead of GCM, some lines should be removed from `AndroidManifest.xml`, as explained [here](https://developers.google.com/cloud-messaging/android/android-migrate-fcm). 

If you don't remove them, notifications are received twice 🙂 

I updated the README. 

If you want, I can rework the documentation a little more to explain usage with FCM, this would fix [some issues](https://github.com/zo0r/react-native-push-notification/search?q=fcm&type=Issues) as the library is working well with FCM. 