### PR TITLE
Add clearLocalNotification method

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -195,6 +195,14 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
     }
 
     @ReactMethod
+        /**
+         * Clear notification from the notification centre.
+         */
+        public void clearLocalNotification(int notificationID) {
+            mRNPushNotificationHelper.clearNotification(notificationID);
+        }
+
+    @ReactMethod
     public void registerNotificationActions(ReadableArray actions) {
         registerNotificationsReceiveNotificationActions(actions);
     }

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -406,6 +406,13 @@ public class RNPushNotificationHelper {
         notificationManager.cancelAll();
     }
 
+    public void clearNotification(int notificationID) {
+        Log.i(LOG_TAG, "Clearing notification: " + notificationID);
+
+        NotificationManager notificationManager = notificationManager();
+        notificationManager.cancel(notificationID);
+    }
+
     public void cancelAllScheduledNotifications() {
         Log.i(LOG_TAG, "Cancelling all notifications");
 

--- a/component/index.android.js
+++ b/component/index.android.js
@@ -34,6 +34,10 @@ NotificationsComponent.prototype.cancelLocalNotifications = function(details: Ob
 	RNPushNotification.cancelLocalNotifications(details);
 };
 
+NotificationsComponent.prototype.clearLocalNotification = function(details: Object) {
+	RNPushNotification.clearLocalNotification(details);
+};
+
 NotificationsComponent.prototype.cancelAllLocalNotifications = function() {
 	RNPushNotification.cancelAllLocalNotifications();
 };

--- a/index.js
+++ b/index.js
@@ -286,6 +286,10 @@ Notifications.cancelLocalNotifications = function() {
 	return this.callNative('cancelLocalNotifications', arguments);
 };
 
+Notifications.clearLocalNotification = function() {
+    return this.callNative('clearLocalNotification', arguments);
+};
+
 Notifications.cancelAllLocalNotifications = function() {
 	return this.callNative('cancelAllLocalNotifications', arguments);
 };


### PR DESCRIPTION
As discussed in #371 there is no way to remove a notification from the notification centre.
This PR adds a method that removes a notification by id from the centre.