### PR TITLE
add `checkPermissions` for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,9 +317,16 @@ Uses the [ShortcutBadger](https://github.com/leolin310148/ShortcutBadger) on And
 ## Sending Notification Data From Server
 Same parameters as `PushNotification.localNotification()`
 
-## iOS Only Methods
+## Checking Notification Permissions
 `PushNotification.checkPermissions(callback: Function)` Check permissions
 
-`PushNotification.getApplicationIconBadgeNumber(callback: Function)` get badge number
+`callback` will be invoked with a `permissions` object:
+- `alert`: boolean
+- `badge`: boolean
+- `sound`: boolean
+
+## iOS Only Methods
+
+`PushNotification.getApplicationIconBadgeNumber(callback: Function)` Get badge number
 
 `PushNotification.abandonPermissions()` Abandon permissions

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
+import android.support.v4.app.NotificationManagerCompat;
 
 import com.dieam.reactnativepushnotification.helpers.ApplicationBadgeHelper;
 import com.facebook.react.bridge.ActivityEventListener;
@@ -103,6 +104,13 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
                 manager.cancel(notificationID);
             }
         }, intentFilter);
+    }
+
+    @ReactMethod
+    public void checkPermissions(Promise promise) {
+        ReactContext reactContext = getReactApplicationContext();
+        NotificationManagerCompat managerCompat = NotificationManagerCompat.from(reactContext);
+        promise.resolve(managerCompat.areNotificationsEnabled());
     }
 
     @ReactMethod

--- a/component/index.android.js
+++ b/component/index.android.js
@@ -58,7 +58,7 @@ NotificationsComponent.prototype.abandonPermissions = function() {
 };
 
 NotificationsComponent.prototype.checkPermissions = function(callback: Function) {
-	/* Void */
+	RNPushNotification.checkPermissions().then(alert => callback({ alert }));
 };
 
 NotificationsComponent.prototype.addEventListener = function(type: string, handler: Function) {


### PR DESCRIPTION
Follows the same method signature as the existing one for iOS.
Tested on Android 5.0 and 8.0.