### PR TITLE
Update RNPushNotification.java for notification retrieval when the app is in the background/killed

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
+import android.support.v4.app.NotificationManagerCompat;
 
 import com.dieam.reactnativepushnotification.helpers.ApplicationBadgeHelper;
 import com.facebook.react.bridge.ActivityEventListener;
@@ -116,6 +117,13 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
     }
 
     @ReactMethod
+    public void checkPermissions(Promise promise) {
+        ReactContext reactContext = getReactApplicationContext();
+        NotificationManagerCompat managerCompat = NotificationManagerCompat.from(reactContext);
+        promise.resolve(managerCompat.areNotificationsEnabled());
+    }
+
+    @ReactMethod
     public void requestPermissions(String senderID) {
         ReactContext reactContext = getReactApplicationContext();
 
@@ -214,6 +222,14 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
      */
     public void cancelLocalNotifications(ReadableMap userInfo) {
         mRNPushNotificationHelper.cancelScheduledNotification(userInfo);
+    }
+
+    @ReactMethod
+    /**
+     * Clear notification from the notification centre.
+     */
+    public void clearLocalNotification(int notificationID) {
+        mRNPushNotificationHelper.clearNotification(notificationID);
     }
 
     @ReactMethod


### PR DESCRIPTION
As reflected in https://github.com/zo0r/react-native-push-notification/issues/547 - ComicScrip's suggestion.

_Rationale:_ While local notifications work properly in the following three use-cases: app in the foreground, background and killed, this is not the case for remote notifications.  For remote notifications, only the first use case (foreground), results in a notification object one can work with. The other two use cases do work properly, but one does not retrieve a notification object in the popInitialNotification callback (i.e. it is null). 

The _expected behaviour_ of the application w/ these changes is thus:
- One is able to receive a remote notification (and being able to retrieve its respective object) while the app is in the background
- One is able to receive a remote notification (and being able to retrieve its respective object) while the app is killed.
- All the other functionalities (e.g. receiving a remote notification while the app is in the foreground, local notifications work properly in all the three use cases etc) remain functional
