### PR TITLE
Fix title and message for Firebase

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
@@ -30,8 +30,14 @@ public class RNPushNotificationListenerService extends FirebaseMessagingService 
     @Override
     public void onMessageReceived(RemoteMessage message) {
         String from = message.getFrom();
+        RemoteMessage.Notification remoteNotification = message.getNotification();
 
         final Bundle bundle = new Bundle();
+        // Putting it from remoteNotification first so it can be overriden if message
+        // data has it
+        bundle.putString("title", remoteNotification.getTitle());
+        bundle.putString("message", remoteNotification.getBody());
+
         for(Map.Entry<String, String> entry : message.getData().entrySet()) {
             bundle.putString(entry.getKey(), entry.getValue());
         }

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
@@ -35,8 +35,11 @@ public class RNPushNotificationListenerService extends FirebaseMessagingService 
         final Bundle bundle = new Bundle();
         // Putting it from remoteNotification first so it can be overriden if message
         // data has it
-        bundle.putString("title", remoteNotification.getTitle());
-        bundle.putString("message", remoteNotification.getBody());
+        if (remoteNotification != null) {
+            // ^ It's null when message is from GCM
+            bundle.putString("title", remoteNotification.getTitle());
+            bundle.putString("message", remoteNotification.getBody());
+        }
 
         for(Map.Entry<String, String> entry : message.getData().entrySet()) {
             bundle.putString(entry.getKey(), entry.getValue());


### PR DESCRIPTION
`title` and `body` are special props when coming from GCM/Firebase compat. Their keys are prefixed with `gcm.` which is ignored when `getData()` returns it's data.

We have to use the remote notification APIs to get access to those properties.

I've added these new props before iterating the data bundle so data can override this, making this change backward-compatible.