### PR TITLE
Fix requestPermissions crash (Issue #803)

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -130,8 +130,12 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
 
         Intent GCMService = new Intent(reactContext, RNPushNotificationRegistrationService.class);
 
-        GCMService.putExtra("senderID", senderID);
-        reactContext.startService(GCMService);
+        try {
+            GCMService.putExtra("senderID", senderID);
+            reactContext.startService(GCMService);
+        } catch (Exception e) {
+            Log.d("EXCEPTION SERVICE::::::", "requestPermissions: " + e);
+        }
     }
 
     @ReactMethod


### PR DESCRIPTION
I added a try catch block in requestPermissions.
This ensure that the app doesn't crash when in background.
It should fix Issue #803.