### PR TITLE
Allow configuring notification channel and color through manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,13 @@ In your `AndroidManifest.xml`
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 
-    <meta-data       android:name="com.dieam.reactnativepushnotification.notification_channel_name"
-                     android:value="YOUR NOTIFICATION CHANNEL NAME"/>
-    <meta-data       android:name="com.dieam.reactnativepushnotification.notification_channel_description"
-                     android:value="YOUR NOTIFICATION CHANNEL DESCRIPTION"/>
+    <meta-data  android:name="com.dieam.reactnativepushnotification.notification_channel_name"
+                android:value="YOUR NOTIFICATION CHANNEL NAME"/>
+    <meta-data  android:name="com.dieam.reactnativepushnotification.notification_channel_description"
+                android:value="YOUR NOTIFICATION CHANNEL DESCRIPTION"/>
+    <!-- Change the resource name to your App's accent color - or any other color you want -->
+    <meta-data  android:name="com.dieam.reactnativepushnotification.notification_color"
+                android:resource="@android:color/white"/>
 
     <application ....>
         <!-- <Only if you're using GCM> -->

--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ In your `AndroidManifest.xml`
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 
+    <meta-data       android:name="com.dieam.reactnativepushnotification.notification_channel_name"
+                     android:value="YOUR NOTIFICATION CHANNEL NAME"/>
+    <meta-data       android:name="com.dieam.reactnativepushnotification.notification_channel_description"
+                     android:value="YOUR NOTIFICATION CHANNEL DESCRIPTION"/>
+
     <application ....>
         <!-- <Only if you're using GCM> -->
         <receiver
@@ -272,7 +277,7 @@ In the location notification json specify the full file name:
 The `id` parameter for `PushNotification.localNotification` is required for this operation. The id supplied will then be used for the cancel operation.
 
 ```javascript
-// Android 
+// Android
 PushNotification.localNotification({
     ...
     id: '123'
@@ -284,7 +289,7 @@ PushNotification.cancelLocalNotifications({id: '123'});
 #### IOS
 The `userInfo` parameter for `PushNotification.localNotification` is required for this operation and must contain an `id` parameter. The id supplied will then be used for the cancel operation.
 ```javascript
-// IOS 
+// IOS
 PushNotification.localNotification({
     ...
     userInfo: { id: '123' }

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -41,10 +41,9 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
         reactContext.addActivityEventListener(this);
 
         Application applicationContext = (Application) reactContext.getApplicationContext();
-        RNPushNotificationConfig config = new RNPushNotificationConfig(applicationContext);
 
         // The @ReactNative methods use this
-        mRNPushNotificationHelper = new RNPushNotificationHelper(applicationContext, config);
+        mRNPushNotificationHelper = new RNPushNotificationHelper(applicationContext);
         // This is used to delivery callbacks to JS
         mJsDelivery = new RNPushNotificationJsDelivery(reactContext);
 

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -41,8 +41,10 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
         reactContext.addActivityEventListener(this);
 
         Application applicationContext = (Application) reactContext.getApplicationContext();
+        RNPushNotificationConfig config = new RNPushNotificationConfig(applicationContext);
+
         // The @ReactNative methods use this
-        mRNPushNotificationHelper = new RNPushNotificationHelper(applicationContext);
+        mRNPushNotificationHelper = new RNPushNotificationHelper(applicationContext, config);
         // This is used to delivery callbacks to JS
         mJsDelivery = new RNPushNotificationJsDelivery(reactContext);
 

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationConfig.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationConfig.java
@@ -10,7 +10,7 @@ import android.util.Log;
 class RNPushNotificationConfig {
     private static final String KEY_CHANNEL_NAME = "com.dieam.reactnativepushnotification.notification_channel_name";
     private static final String KEY_CHANNEL_DESCRIPTION = "com.dieam.reactnativepushnotification.notification_channel_description";
-    private static final String KEY_NOTIFICATION_ICON = "com.dieam.reactnativepushnotification.notification_color";
+    private static final String KEY_NOTIFICATION_COLOR = "com.dieam.reactnativepushnotification.notification_color";
 
     private static Bundle metadata;
     private Context context;
@@ -33,7 +33,7 @@ class RNPushNotificationConfig {
         try {
             return metadata.getString(KEY_CHANNEL_NAME);
         } catch (Exception e) {
-            Log.e(RNPushNotification.LOG_TAG, "Unable to find " + KEY_CHANNEL_NAME + " in manifest. Falling back to default");
+            Log.w(RNPushNotification.LOG_TAG, "Unable to find " + KEY_CHANNEL_NAME + " in manifest. Falling back to default");
         }
         // Default
         return "rn-push-notification-channel";
@@ -42,17 +42,17 @@ class RNPushNotificationConfig {
         try {
             return metadata.getString(KEY_CHANNEL_DESCRIPTION);
         } catch (Exception e) {
-            Log.e(RNPushNotification.LOG_TAG, "Unable to find " + KEY_CHANNEL_DESCRIPTION + " in manifest. Falling back to default");
+            Log.w(RNPushNotification.LOG_TAG, "Unable to find " + KEY_CHANNEL_DESCRIPTION + " in manifest. Falling back to default");
         }
         // Default
         return "";
     }
     public int getNotificationColor() {
         try {
-            int resourceId = metadata.getInt(KEY_NOTIFICATION_ICON);
+            int resourceId = metadata.getInt(KEY_NOTIFICATION_COLOR);
             return ResourcesCompat.getColor(context.getResources(), resourceId, null);
         } catch (Exception e) {
-            Log.e(RNPushNotification.LOG_TAG, "Unable to find " + KEY_NOTIFICATION_ICON + " in manifest. Falling back to default");
+            Log.w(RNPushNotification.LOG_TAG, "Unable to find " + KEY_NOTIFICATION_COLOR + " in manifest. Falling back to default");
         }
         // Default
         return -1;

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationConfig.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationConfig.java
@@ -3,6 +3,7 @@ package com.dieam.reactnativepushnotification.modules;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
+import android.support.v4.content.res.ResourcesCompat;
 import android.os.Bundle;
 import android.util.Log;
 
@@ -12,8 +13,10 @@ class RNPushNotificationConfig {
     private static final String KEY_NOTIFICATION_ICON = "com.dieam.reactnativepushnotification.notification_color";
 
     private static Bundle metadata;
+    private Context context;
 
     public RNPushNotificationConfig(Context context) {
+        this.context = context;
         if (metadata == null) {
             try {
                 ApplicationInfo applicationInfo = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
@@ -46,7 +49,8 @@ class RNPushNotificationConfig {
     }
     public int getNotificationColor() {
         try {
-            return metadata.getInt(KEY_NOTIFICATION_ICON);
+            int resourceId = metadata.getInt(KEY_NOTIFICATION_ICON);
+            return ResourcesCompat.getColor(context.getResources(), resourceId, null);
         } catch (Exception e) {
             Log.e(RNPushNotification.LOG_TAG, "Unable to find " + KEY_NOTIFICATION_ICON + " in manifest. Falling back to default");
         }

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationConfig.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationConfig.java
@@ -1,0 +1,44 @@
+package com.dieam.reactnativepushnotification.modules;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+import android.util.Log;
+
+class RNPushNotificationConfig {
+    private static final String KEY_CHANNEL_NAME = "com.dieam.reactnativepushnotification.notification_channel_name";
+    private static final String KEY_CHANNEL_DESCRIPTION = "com.dieam.reactnativepushnotification.notification_channel_description";
+
+    private Bundle metadata;
+
+    public RNPushNotificationConfig(Context context) {
+        try {
+            ApplicationInfo applicationInfo = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+            metadata = applicationInfo.metaData;
+        } catch (PackageManager.NameNotFoundException e) {
+            e.printStackTrace();
+            Log.e(RNPushNotification.LOG_TAG, "Error reading application meta, falling back to defaults");
+            metadata = new Bundle();
+        }
+    }
+
+    public String getChannelName() {
+        try {
+            return metadata.getString(KEY_CHANNEL_NAME);
+        } catch (Exception e) {
+            Log.e(RNPushNotification.LOG_TAG, "Unable to find " + KEY_CHANNEL_NAME + " in manifest. Falling back to default");
+        }
+        // Default
+        return "rn-push-notification-channel";
+    }
+    public String getChannelDescription() {
+        try {
+            return metadata.getString(KEY_CHANNEL_DESCRIPTION);
+        } catch (Exception e) {
+            Log.e(RNPushNotification.LOG_TAG, "Unable to find " + KEY_CHANNEL_DESCRIPTION + " in manifest. Falling back to default");
+        }
+        // Default
+        return "";
+    }
+}

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationConfig.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationConfig.java
@@ -9,6 +9,7 @@ import android.util.Log;
 class RNPushNotificationConfig {
     private static final String KEY_CHANNEL_NAME = "com.dieam.reactnativepushnotification.notification_channel_name";
     private static final String KEY_CHANNEL_DESCRIPTION = "com.dieam.reactnativepushnotification.notification_channel_description";
+    private static final String KEY_NOTIFICATION_ICON = "com.dieam.reactnativepushnotification.notification_color";
 
     private static Bundle metadata;
 
@@ -42,5 +43,14 @@ class RNPushNotificationConfig {
         }
         // Default
         return "";
+    }
+    public int getNotificationColor() {
+        try {
+            return metadata.getInt(KEY_NOTIFICATION_ICON);
+        } catch (Exception e) {
+            Log.e(RNPushNotification.LOG_TAG, "Unable to find " + KEY_NOTIFICATION_ICON + " in manifest. Falling back to default");
+        }
+        // Default
+        return -1;
     }
 }

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationConfig.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationConfig.java
@@ -10,16 +10,18 @@ class RNPushNotificationConfig {
     private static final String KEY_CHANNEL_NAME = "com.dieam.reactnativepushnotification.notification_channel_name";
     private static final String KEY_CHANNEL_DESCRIPTION = "com.dieam.reactnativepushnotification.notification_channel_description";
 
-    private Bundle metadata;
+    private static Bundle metadata;
 
     public RNPushNotificationConfig(Context context) {
-        try {
-            ApplicationInfo applicationInfo = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
-            metadata = applicationInfo.metaData;
-        } catch (PackageManager.NameNotFoundException e) {
-            e.printStackTrace();
-            Log.e(RNPushNotification.LOG_TAG, "Error reading application meta, falling back to defaults");
-            metadata = new Bundle();
+        if (metadata == null) {
+            try {
+                ApplicationInfo applicationInfo = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+                metadata = applicationInfo.metaData;
+            } catch (PackageManager.NameNotFoundException e) {
+                e.printStackTrace();
+                Log.e(RNPushNotification.LOG_TAG, "Error reading application meta, falling back to defaults");
+                metadata = new Bundle();
+            }
         }
     }
 

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -38,13 +38,15 @@ public class RNPushNotificationHelper {
     private static final String NOTIFICATION_CHANNEL_ID = "rn-push-notification-channel-id";
 
     private Context context;
+    private RNPushNotificationConfig config;
     private final SharedPreferences scheduledNotificationsPersistence;
     private static final int ONE_MINUTE = 60 * 1000;
     private static final long ONE_HOUR = 60 * ONE_MINUTE;
     private static final long ONE_DAY = 24 * ONE_HOUR;
 
-    public RNPushNotificationHelper(Application context) {
+    public RNPushNotificationHelper(Application context, RNPushNotificationConfig config) {
         this.context = context;
+        this.config = config;
         this.scheduledNotificationsPersistence = context.getSharedPreferences(RNPushNotificationHelper.PREFERENCES_KEY, Context.MODE_PRIVATE);
     }
 
@@ -476,7 +478,7 @@ public class RNPushNotificationHelper {
     }
 
     private static boolean channelCreated = false;
-    private static void checkOrCreateChannel(NotificationManager manager) {
+    private void checkOrCreateChannel(NotificationManager manager) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
             return;
         if (channelCreated)
@@ -484,9 +486,9 @@ public class RNPushNotificationHelper {
         if (manager == null)
             return;
 
-        final CharSequence name = "rn-push-notification-channel";
         int importance = NotificationManager.IMPORTANCE_DEFAULT;
-        NotificationChannel channel = new NotificationChannel(NOTIFICATION_CHANNEL_ID, name, importance);
+        NotificationChannel channel = new NotificationChannel(NOTIFICATION_CHANNEL_ID, this.config.getChannelName(), importance);
+        channel.setDescription(this.config.getChannelDescription());
         channel.enableLights(true);
         channel.enableVibration(true);
 

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -265,8 +265,11 @@ public class RNPushNotificationHelper {
                 notification.setCategory(NotificationCompat.CATEGORY_CALL);
 
                 String color = bundle.getString("color");
+                int defaultColor = this.config.getNotificationColor();
                 if (color != null) {
                     notification.setColor(Color.parseColor(color));
+                } else if (defaultColor != -1) {
+                    notification.setColor(defaultColor);
                 }
             }
 

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -44,9 +44,9 @@ public class RNPushNotificationHelper {
     private static final long ONE_HOUR = 60 * ONE_MINUTE;
     private static final long ONE_DAY = 24 * ONE_HOUR;
 
-    public RNPushNotificationHelper(Application context, RNPushNotificationConfig config) {
+    public RNPushNotificationHelper(Application context) {
         this.context = context;
-        this.config = config;
+        this.config = new RNPushNotificationConfig(context);
         this.scheduledNotificationsPersistence = context.getSharedPreferences(RNPushNotificationHelper.PREFERENCES_KEY, Context.MODE_PRIVATE);
     }
 


### PR DESCRIPTION
This PR follows the metadata approach as encouraged by [firebase sdk](https://firebase.google.com/docs/cloud-messaging/android/topic-messaging#edit-the-app-manifest) itself. See the linked issues for details

Fixes https://github.com/zo0r/react-native-push-notification/issues/820 https://github.com/zo0r/react-native-push-notification/issues/814
Closes https://github.com/zo0r/react-native-push-notification/pull/815
