### PR TITLE
Standardize Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,22 @@
-# Changelog react-native-push-notification
+# Changelog
+All notable changes to this project will be documented in this file.
 
-## v3.1.1
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [3.1.1] - 2018-07-31
+
+## Added
 - Android Oreo support (SDK >= 26) (PR [#657](https://github.com/zo0r/react-native-push-notification/pull/657))
 - Firebase (FCM) Support (PR [#717](https://github.com/zo0r/react-native-push-notification/pull/717))
 - Twilio support (PR [#744](https://github.com/zo0r/react-native-push-notification/pull/744))
+- clearLocalNotification (PR [#711](https://github.com/zo0r/react-native-push-notification/pull/711))
+
+## Fixed
 - checkPermissions (PR [#721](https://github.com/zo0r/react-native-push-notification/pull/721))
 - Remove default alert for silent push (PR [#707](https://github.com/zo0r/react-native-push-notification/pull/707))
-- clearLocalNotification (PR [#711](https://github.com/zo0r/react-native-push-notification/pull/711))
+
+[Unreleased]: https://github.com/zo0r/react-native-push-notification/compare/v3.1.1...HEAD
+[3.1.1]: https://github.com/zo0r/react-native-push-notification/compare/...v3.1.1


### PR DESCRIPTION
Use [keepachangelog](https://keepachangelog.com/en/1.0.0/) conventions to provide a clear description of the changes between versions as proposed [here](https://github.com/zo0r/react-native-push-notification/issues/785#issue-340168647).
It is recommended to enforce a workflow where contributors describe changes made in PRs in the changelog as explained [here](https://github.com/react-navigation/react-navigation/pull/4544#issuecomment-399355299).