### PR TITLE
Android API 26+ fixed heads-up notifications

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -492,7 +492,7 @@ public class RNPushNotificationHelper {
         if (manager == null)
             return;
 
-        int importance = NotificationManager.IMPORTANCE_DEFAULT;
+        int importance = NotificationManager.IMPORTANCE_HIGH;
         NotificationChannel channel = new NotificationChannel(NOTIFICATION_CHANNEL_ID, this.config.getChannelName(), importance);
         channel.setDescription(this.config.getChannelDescription());
         channel.enableLights(true);


### PR DESCRIPTION
Starting in Android API 26+ the notification channel needs **high importance** in order to display heads-up notifications. We upgraded our app from target API 22 to 27 and noticed that the heads-up notifications no longer worked for our local notifications. In this pull-request, I just changed the **NotificationChannel** importance to **high** instead of **default**. This resolved the issue. 

Please review the **heads-up notification** section. 
https://developer.android.com/guide/topics/ui/notifiers/notifications