### PR TITLE
Update documentation to avoid falling Androids' build

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The component uses PushNotificationIOS for the iOS part.
 
 ## Android manual Installation
 
-**NOTE: To use a specific `play-service-gcm` or `firebase-messaging` version:**
+**NOTE: `play-service-gcm` and `firebase-messaging`, prior to version 15 requires to have the same version number in order to work correctly at build time and at run time. To use a specific version:**
 
 In your `android/build.gradle`
 ```gradle


### PR DESCRIPTION
As specified  in this link: 
https://android-developers.googleblog.com/2018/05/announcing-new-sdk-versioning.html

Prior to version 15 firebase and google-play-services, should have the same version, in our project we specified google-play-services version to 11, but not firebase, so Android builds started to fail, since this was not specified in the docs, I had to research and came across to that article, specifying the same version for both worked like a charm! Also I believe this fixes this [issue](https://github.com/zo0r/react-native-push-notification/issues/830)