### PR TITLE
Fix importance level always set to high

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -323,7 +323,7 @@ public class RNPushNotificationHelper {
                     PendingIntent.FLAG_UPDATE_CURRENT);
 
             NotificationManager notificationManager = notificationManager();
-            checkOrCreateChannel(notificationManager);
+            checkOrCreateChannel(bundle, notificationManager);
 
             notification.setContentIntent(pendingIntent);
 
@@ -528,15 +528,13 @@ public class RNPushNotificationHelper {
     }
 
     private static boolean channelCreated = false;
-    private void checkOrCreateChannel(NotificationManager manager) {
+    private void checkOrCreateChannel(Bundle bundle, NotificationManager manager) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
             return;
         if (channelCreated)
             return;
         if (manager == null)
             return;
-
-        Bundle bundle = new Bundle();
 
         int importance = NotificationManager.IMPORTANCE_HIGH;
         final String importanceString = bundle.getString("importance");


### PR DESCRIPTION
When creating the NotificationChannel, it was reading the important level from a new Bundle instead of using the one that already exist.
I just added to the method checkOrCreateChannel, the bundle in parameter since its only used from one place and from there you already have the bundle.