### PR TITLE
Update to android/build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,11 +48,11 @@ dependencies {
     def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
     def firebaseVersion = project.hasProperty('firebaseVersion') ? project.firebaseVersion : DEFAULT_FIREBASE_MESSAGING_VERSION
 
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
-    compile "com.android.support:appcompat-v7:$supportLibVersion"
-    compile 'com.facebook.react:react-native:+'
-    compile "com.google.android.gms:play-services-gcm:$googlePlayServicesVersion"
-    compile 'me.leolin:ShortcutBadger:1.1.8@aar'
-    compile "com.google.firebase:firebase-messaging:$firebaseVersion"
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    testImplementation 'junit:junit:4.12'
+    implementation "com.android.support:appcompat-v7:$supportLibVersion"
+    compileOnly 'com.facebook.react:react-native:+'
+    implementation "com.google.android.gms:play-services-gcm:$googlePlayServicesVersion"
+    implementation 'me.leolin:ShortcutBadger:1.1.8@aar'
+    implementation "com.google.firebase:firebase-messaging:$firebaseVersion"
 }


### PR DESCRIPTION
Related to issue #895 
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
WARNING: Configuration 'testCompile' is obsolete and has been replaced with 'testImplementation' and 'testApi'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html