### PR TITLE
Properly handle default values of metadata

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationConfig.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationConfig.java
@@ -31,7 +31,10 @@ class RNPushNotificationConfig {
 
     public String getChannelName() {
         try {
-            return metadata.getString(KEY_CHANNEL_NAME);
+            final String name = metadata.getString(KEY_CHANNEL_NAME);
+            if (name != null && name.length() > 0) {
+                return name;
+            }
         } catch (Exception e) {
             Log.w(RNPushNotification.LOG_TAG, "Unable to find " + KEY_CHANNEL_NAME + " in manifest. Falling back to default");
         }
@@ -40,7 +43,10 @@ class RNPushNotificationConfig {
     }
     public String getChannelDescription() {
         try {
-            return metadata.getString(KEY_CHANNEL_DESCRIPTION);
+            final String description = metadata.getString(KEY_CHANNEL_DESCRIPTION);
+            if (description != null) {
+                return description;
+            }
         } catch (Exception e) {
             Log.w(RNPushNotification.LOG_TAG, "Unable to find " + KEY_CHANNEL_DESCRIPTION + " in manifest. Falling back to default");
         }


### PR DESCRIPTION
`getString` returns `null` if mapping does not exist for a key.
(https://developer.android.com/reference/android/os/BaseBundle.html#getString(java.lang.String))

also `createNotificationChannel`
(https://developer.android.com/reference/android/app/NotificationManager#createNotificationChannel(android.app.notificationchanne))
fails if channel name is an empty string.

*update*
A bit more clearer explanation: w/o this fix if channel name is not provided through manifest the `getChannelName` will return `null` and the following call to `createNotificationChannel` (https://github.com/zo0r/react-native-push-notification/blob/master/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java#L577) will fail with exception, which will be swallowed here https://github.com/zo0r/react-native-push-notification/blob/master/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java#L402 and entire flow will silently fail and no notifications will be shown to a user.