### PR TITLE
[Android] Allow to set the notification to executes on idle

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ PushNotification.localNotification({
     priority: "high", // (optional) set notification priority, default: high
     visibility: "private", // (optional) set notification visibility, default: private
     importance: "high", // (optional) set notification importance, default: high
+    allowWhileIdle: false, // (optional) set notification to work while on doze, default: false
 
     /* iOS only properties */
     alertAction: // (optional) default: view
@@ -347,6 +348,17 @@ Available options:
 "unspecified" = NotificationManager.IMPORTANCE_UNSPECIFIED  
 
 More information: https://developer.android.com/reference/android/app/NotificationManager#IMPORTANCE_DEFAULT
+
+## Notification while idle  ##
+
+(optional) Specify `allowWhileIdle` to set if the notification should be allowed to execute even when the system is on low-power idle modes.
+
+On Android 6.0 (API level 23) and forward, the Doze was introduced  to reduce battery consumption when the device is unused for long periods of time. But while on Doze the AlarmManager alarms (used to show scheduled notifications) are deferred to the next maintenance window. This may cause the notification to be delayed while on Doze.
+
+This can significantly impact the power use of the device when idle. So it must only be used when the notification is required to go off on a exact time, for example on a calendar notification.
+
+More information:
+https://developer.android.com/training/monitoring-device-state/doze-standby
 
 #### IOS
 The `userInfo` parameter for `PushNotification.localNotification` is required for this operation and must contain an `id` parameter. The id supplied will then be used for the cancel operation.

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -118,6 +118,7 @@ public class RNPushNotificationHelper {
 
     public void sendNotificationScheduledCore(Bundle bundle) {
         long fireDate = (long) bundle.getDouble("fireDate");
+        boolean allowWhileIdle = bundle.getBoolean("allowWhileIdle");
 
         // If the fireDate is in past, this will fire immediately and show the
         // notification to the user
@@ -126,7 +127,11 @@ public class RNPushNotificationHelper {
         Log.d(LOG_TAG, String.format("Setting a notification with id %s at time %s",
                 bundle.getString("id"), Long.toString(fireDate)));
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            getAlarmManager().setExact(AlarmManager.RTC_WAKEUP, fireDate, pendingIntent);
+            if(allowWhileIdle && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                getAlarmManager().setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, fireDate, pendingIntent);
+            } else {
+                getAlarmManager().setExact(AlarmManager.RTC_WAKEUP, fireDate, pendingIntent);
+            }
         } else {
             getAlarmManager().set(AlarmManager.RTC_WAKEUP, fireDate, pendingIntent);
         }


### PR DESCRIPTION
On Android 6.0 (API level 23) and above in order to reduce battery consumption, the system enters in Doze mode while the device is unused for long periods of time.
While on Doze mode the AlarmManager alarms dont execute exactly on the scheduled time, they are deferred to the next maintenance window. This cause the notifications to show after their scheduled time.
This change adds a new attribute `allowWhileIdle` to allow the notification to be displayed while on doze

This behavior is documented on: https://developer.android.com/training/monitoring-device-state/doze-standby