### PR TITLE
bug fix related to NotificationChannel in android 8.1, API 26

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -569,12 +569,13 @@ public class RNPushNotificationHelper {
             }
         }
 
-        NotificationChannel channel = new NotificationChannel(NOTIFICATION_CHANNEL_ID, this.config.getChannelName(), importance);
-        channel.setDescription(this.config.getChannelDescription());
-        channel.enableLights(true);
-        channel.enableVibration(true);
-
-        manager.createNotificationChannel(channel);
+        NotificationChannel mChannel = manager.getNotificationChannel(NOTIFICATION_CHANNEL_ID);
+        if (mChannel == null) {
+        mChannel = new NotificationChannel(NOTIFICATION_CHANNEL_ID, "Channel name", NotificationManager.IMPORTANCE_MAX);
+        mChannel.enableVibration(true);
+        mChannel.setVibrationPattern(new long[]{100, 200, 300, 400, 500, 400, 300, 200, 400});
+        manager.createNotificationChannel(mChannel);
+        }
         channelCreated = true;
     }
 }


### PR DESCRIPTION
Fixing issue of handling notification in android 8.1
the library works great for older version < API 26, but when it cams to API 26 or higher ,notifications does not display anymore.

So i solved this problem after spending several days looking for a solution , i changed some line of code in RNPushNotificationHelper.java file, such as testing if NotificationChannel channel is already created or not .
I posted the solution in SOF [here](https://stackoverflow.com/questions/55214424/react-native-push-notification-doesnt-work-in-android-8-1-api-level-27)