### PR TITLE
Update NotifService.js

### DIFF
--- a/example/NotifService.js
+++ b/example/NotifService.js
@@ -59,8 +59,8 @@ export default class NotifService {
 
       /* iOS only properties */
       alertAction: 'view', // (optional) default: view
-      category: null, // (optional) default: null
-      userInfo: null, // (optional) default: null (object containing additional notification data)
+      category: '', // (optional) default: empty string
+      userInfo: {}, // (optional) default: {} (using null throws a JSON value '<null>' error)
 
       /* iOS and Android properties */
       title: "Local Notification", // (optional)


### PR DESCRIPTION
Fixes an error thrown when running the Example using iOS simulator as a notification is sent:
```JSON value '<null>' of type NSNull cannot be converted to NSDictionary```

Fixes the issue raised here: https://github.com/zo0r/react-native-push-notification/issues/843

![image](https://user-images.githubusercontent.com/39765499/55269399-7bf30780-528a-11e9-9811-43451231d05f.png)
