### PR TITLE
ignore .git closes #1057

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -60,3 +60,6 @@ local.properties
 
 # Example app
 example
+
+# Git
+.git 


### PR DESCRIPTION
This PR just adds the .git file to the .npmignore so that it is ignored when used. Someone just forgot to add it in at some point.