### PR TITLE
Constrain gcm version to 16.1.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     implementation "com.android.support:appcompat-v7:${safeExtGet('supportLibVersion', '28.0.0')}"
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    implementation "com.google.android.gms:play-services-gcm:${safeExtGet('googlePlayServicesVersion', '+')}"
+    implementation "com.google.android.gms:play-services-gcm:${safeExtGet('googlePlayServicesVersion', '16.1.0')}"
     implementation 'me.leolin:ShortcutBadger:1.1.8@aar'
     implementation "com.google.firebase:firebase-messaging:${safeExtGet('firebaseVersion', '+')}"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,5 +47,5 @@ dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
     implementation "com.google.android.gms:play-services-gcm:${safeExtGet('googlePlayServicesVersion', '16.1.0')}"
     implementation 'me.leolin:ShortcutBadger:1.1.8@aar'
-    implementation "com.google.firebase:firebase-messaging:${safeExtGet('firebaseVersion', '+')}"
+    implementation "com.google.firebase:firebase-messaging:${safeExtGet('firebaseVersion', '17.6.0')}"
 }


### PR DESCRIPTION
With the latest firebase/gcm release (https://developers.google.com/android/guides/releases), the latest version (+) now brings in androidx dependencies. react-native won't be ready for androidx until 0.60 so constraint the gcm version to 16.1.0 (the latest pre-androidx version)

Thanks to @benoitdion for this exact fix on `react-native-device-info` (https://github.com/react-native-community/react-native-device-info/pull/693)