### PR TITLE
Added support to custom NotificationChannelID and default notificationIcon

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ In your `AndroidManifest.xml`
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 
     <application ....>
+        <!-- < Only if you're using Firebase > -->
+        <meta-data  android:name="com.google.firebase.messaging.default_notification_channel_id"
+                    android:value="YOUR-NOTIFICATIONS-CHANNEL-ID-WITHOUT-SPACES"/>
+        <!-- Change the resource name to your App's accent color - or any other color you want -->
+        <meta-data  android:name="com.google.firebase.messaging.default_notification_color"
+                    android:resource="@android:color/white"/>
+        <!-- Change the resource name to your App's icon - or any other icon you want -->
+        <meta-data  android:name="com.google.firebase.messaging.default_notification_icon"
+                    android:resource="@drawable/ic_notification"/>
+        <!-- < Only if you're using Firebase > -->
+
         <meta-data  android:name="com.dieam.reactnativepushnotification.notification_channel_id"
                 android:value="YOUR-NOTIFICATIONS-CHANNEL-ID-WITHOUT-SPACES"/>
         <meta-data  android:name="com.dieam.reactnativepushnotification.notification_channel_name"

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ In your `AndroidManifest.xml`
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 
     <application ....>
+        <meta-data  android:name="com.dieam.reactnativepushnotification.notification_channel_id"
+                android:value="YOUR-NOTIFICATIONS-CHANNEL-ID-WITHOUT-SPACES"/>
         <meta-data  android:name="com.dieam.reactnativepushnotification.notification_channel_name"
                 android:value="YOUR NOTIFICATION CHANNEL NAME"/>
         <meta-data  android:name="com.dieam.reactnativepushnotification.notification_channel_description"
@@ -78,6 +80,9 @@ In your `AndroidManifest.xml`
         <!-- Change the resource name to your App's accent color - or any other color you want -->
         <meta-data  android:name="com.dieam.reactnativepushnotification.notification_color"
                     android:resource="@android:color/white"/>
+        <!-- Change the resource name to your App's icon - or any other icon you want -->
+        <meta-data  android:name="com.dieam.reactnativepushnotification.notification_icon"
+                    android:resource="@drawable/ic_notification"/>
 
         <!-- < Only if you're using GCM or localNotificationSchedule() > -->
         <receiver
@@ -312,11 +317,11 @@ PushNotification.cancelLocalNotifications({id: '123'});
 
 Available options:
 
-"max" = NotficationCompat.PRIORITY_MAX  
-"high" = NotficationCompat.PRIORITY_HIGH  
-"low" = NotficationCompat.PRIORITY_LOW  
-"min" = NotficationCompat.PRIORITY_MIN  
-"default" = NotficationCompat.PRIORITY_DEFAULT  
+"max" = NotficationCompat.PRIORITY_MAX
+"high" = NotficationCompat.PRIORITY_HIGH
+"low" = NotficationCompat.PRIORITY_LOW
+"min" = NotficationCompat.PRIORITY_MIN
+"default" = NotficationCompat.PRIORITY_DEFAULT
 
 More information: https://developer.android.com/reference/android/app/Notification.html#PRIORITY_DEFAULT
 
@@ -326,9 +331,9 @@ More information: https://developer.android.com/reference/android/app/Notificati
 
 Available options:
 
-"private" = NotficationCompat.VISIBILITY_PRIVATE  
-"public" = NotficationCompat.VISIBILITY_PUBLIC  
-"secret" = NotficationCompat.VISIBILITY_SECRET  
+"private" = NotficationCompat.VISIBILITY_PRIVATE
+"public" = NotficationCompat.VISIBILITY_PUBLIC
+"secret" = NotficationCompat.VISIBILITY_SECRET
 
 More information: https://developer.android.com/reference/android/app/Notification.html#VISIBILITY_PRIVATE
 
@@ -338,13 +343,13 @@ More information: https://developer.android.com/reference/android/app/Notificati
 
 Available options:
 
-"default" = NotificationManager.IMPORTANCE_DEFAULT  
-"max" = NotificationManager.IMPORTANCE_MAX  
-"high" = NotificationManager.IMPORTANCE_HIGH  
-"low" = NotificationManager.IMPORTANCE_LOW  
-"min" = NotificationManager.IMPORTANCE_MIN  
-"none" = NotificationManager.IMPORTANCE_NONE  
-"unspecified" = NotificationManager.IMPORTANCE_UNSPECIFIED  
+"default" = NotificationManager.IMPORTANCE_DEFAULT
+"max" = NotificationManager.IMPORTANCE_MAX
+"high" = NotificationManager.IMPORTANCE_HIGH
+"low" = NotificationManager.IMPORTANCE_LOW
+"min" = NotificationManager.IMPORTANCE_MIN
+"none" = NotificationManager.IMPORTANCE_NONE
+"unspecified" = NotificationManager.IMPORTANCE_UNSPECIFIED
 
 More information: https://developer.android.com/reference/android/app/NotificationManager#IMPORTANCE_DEFAULT
 

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationConfig.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationConfig.java
@@ -8,9 +8,11 @@ import android.os.Bundle;
 import android.util.Log;
 
 class RNPushNotificationConfig {
+    private static final String KEY_CHANNEL_ID = "com.dieam.reactnativepushnotification.notification_channel_id";
     private static final String KEY_CHANNEL_NAME = "com.dieam.reactnativepushnotification.notification_channel_name";
     private static final String KEY_CHANNEL_DESCRIPTION = "com.dieam.reactnativepushnotification.notification_channel_description";
     private static final String KEY_NOTIFICATION_COLOR = "com.dieam.reactnativepushnotification.notification_color";
+    private static final String KEY_NOTIFICATION_ICON = "com.dieam.reactnativepushnotification.notification_icon";
 
     private static Bundle metadata;
     private Context context;
@@ -29,6 +31,15 @@ class RNPushNotificationConfig {
         }
     }
 
+    public String getChannelId() {
+        try {
+            return metadata.getString(KEY_CHANNEL_ID);
+        } catch (Exception e) {
+            Log.w(RNPushNotification.LOG_TAG, "Unable to find " + KEY_CHANNEL_ID + " in manifest. Falling back to default");
+        }
+        // Default
+        return "rn-push-notification-channel-id";
+    }
     public String getChannelName() {
         try {
             return metadata.getString(KEY_CHANNEL_NAME);
@@ -53,6 +64,15 @@ class RNPushNotificationConfig {
             return ResourcesCompat.getColor(context.getResources(), resourceId, null);
         } catch (Exception e) {
             Log.w(RNPushNotification.LOG_TAG, "Unable to find " + KEY_NOTIFICATION_COLOR + " in manifest. Falling back to default");
+        }
+        // Default
+        return -1;
+    }
+    public int getNotificationIcon() {
+        try {
+            return metadata.getInt(KEY_NOTIFICATION_ICON);
+        } catch (Exception e) {
+            Log.w(RNPushNotification.LOG_TAG, "Unable to find " + KEY_NOTIFICATION_ICON + " in manifest. Falling back to default");
         }
         // Default
         return -1;

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -211,11 +211,14 @@ public class RNPushNotificationHelper {
             }
 
             NotificationCompat.Builder notification = new NotificationCompat.Builder(context, this.config.getChannelId())
-                    .setContentTitle(title)
                     .setTicker(bundle.getString("ticker"))
                     .setVisibility(visibility)
                     .setPriority(priority)
                     .setAutoCancel(bundle.getBoolean("autoCancel", true));
+
+            if (!title.isEmpty()) {
+                notification.setContentTitle(title);
+            }
 
             String group = bundle.getString("group");
             if (group != null) {

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -151,7 +151,7 @@ public class RNPushNotificationHelper {
                 return;
             }
 
-            String notificationIdString = bundle.getString("id");
+            String notificationIdString = bundle.getString("notificationId");
             if (notificationIdString == null) {
                 Log.e(LOG_TAG, "No notification ID specified for the notification");
                 return;

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -35,7 +35,6 @@ import static com.dieam.reactnativepushnotification.modules.RNPushNotificationAt
 public class RNPushNotificationHelper {
     public static final String PREFERENCES_KEY = "rn_push_notification";
     private static final long DEFAULT_VIBRATION = 300L;
-    private static final String NOTIFICATION_CHANNEL_ID = "rn-push-notification-channel-id";
 
     private Context context;
     private RNPushNotificationConfig config;
@@ -205,7 +204,7 @@ public class RNPushNotificationHelper {
                 }
             }
 
-            NotificationCompat.Builder notification = new NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ID)
+            NotificationCompat.Builder notification = new NotificationCompat.Builder(context, this.config.getChannelId())
                     .setContentTitle(title)
                     .setTicker(bundle.getString("ticker"))
                     .setVisibility(visibility)
@@ -219,8 +218,6 @@ public class RNPushNotificationHelper {
 
             notification.setContentText(bundle.getString("message"));
 
-            String largeIcon = bundle.getString("largeIcon");
-
             String subText = bundle.getString("subText");
 
             if (subText != null) {
@@ -233,37 +230,32 @@ public class RNPushNotificationHelper {
             }
 
             int smallIconResId;
-            int largeIconResId;
-
             String smallIcon = bundle.getString("smallIcon");
 
             if (smallIcon != null) {
                 smallIconResId = res.getIdentifier(smallIcon, "mipmap", packageName);
             } else {
-                smallIconResId = res.getIdentifier("ic_notification", "mipmap", packageName);
+                smallIconResId = this.config.getNotificationIcon();
             }
 
-            if (smallIconResId == 0) {
-                smallIconResId = res.getIdentifier("ic_launcher", "mipmap", packageName);
+            if (smallIconResId > 0)
+                notification.setSmallIcon(smallIconResId);
 
-                if (smallIconResId == 0) {
-                    smallIconResId = android.R.drawable.ic_dialog_info;
-                }
-            }
+            int largeIconResId;
+            String largeIcon = bundle.getString("largeIcon");
 
             if (largeIcon != null) {
                 largeIconResId = res.getIdentifier(largeIcon, "mipmap", packageName);
             } else {
-                largeIconResId = res.getIdentifier("ic_launcher", "mipmap", packageName);
+                largeIconResId = this.config.getNotificationIcon();
             }
 
             Bitmap largeIconBitmap = BitmapFactory.decodeResource(res, largeIconResId);
 
-            if (largeIconResId != 0 && (largeIcon != null || Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)) {
+            if (largeIconResId > 0 && (largeIcon != null || Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)) {
                 notification.setLargeIcon(largeIconBitmap);
             }
 
-            notification.setSmallIcon(smallIconResId);
             String bigText = bundle.getString("bigText");
 
             if (bigText == null) {
@@ -569,7 +561,7 @@ public class RNPushNotificationHelper {
             }
         }
 
-        NotificationChannel channel = new NotificationChannel(NOTIFICATION_CHANNEL_ID, this.config.getChannelName(), importance);
+        NotificationChannel channel = new NotificationChannel(this.config.getChannelId(), this.config.getChannelName(), importance);
         channel.setDescription(this.config.getChannelDescription());
         channel.enableLights(true);
         channel.enableVibration(true);

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationJsDelivery.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationJsDelivery.java
@@ -65,7 +65,7 @@ public class RNPushNotificationJsDelivery {
             return null;
         }
     }
-    
+
     // a Bundle is not a map, so we have to convert it explicitly
     JSONObject convertJSONObject(Bundle bundle) throws JSONException {
         JSONObject json = new JSONObject();

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
@@ -128,11 +128,13 @@ public class RNPushNotificationListenerService extends FirebaseMessagingService 
             jsDelivery.notifyRemoteFetch(bundle);
         }
 
-        Log.v(LOG_TAG, "sendNotification: " + bundle);
+        if (!isForeground) {
+            Log.v(LOG_TAG, "sendNotification: " + bundle);
 
-        Application applicationContext = (Application) context.getApplicationContext();
-        RNPushNotificationHelper pushNotificationHelper = new RNPushNotificationHelper(applicationContext);
-        pushNotificationHelper.sendToNotificationCentre(bundle);
+            Application applicationContext = (Application) context.getApplicationContext();
+            RNPushNotificationHelper pushNotificationHelper = new RNPushNotificationHelper(applicationContext);
+            pushNotificationHelper.sendToNotificationCentre(bundle);
+        }
     }
 
     private boolean isApplicationInForeground() {

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
@@ -123,19 +123,20 @@ public class RNPushNotificationListenerService extends FirebaseMessagingService 
         RNPushNotificationJsDelivery jsDelivery = new RNPushNotificationJsDelivery(context);
         bundle.putBoolean("foreground", isForeground);
         bundle.putBoolean("userInteraction", false);
-        jsDelivery.notifyNotification(bundle);
 
         // If contentAvailable is set to true, then send out a remote fetch event
         if (bundle.getString("contentAvailable", "false").equalsIgnoreCase("true")) {
             jsDelivery.notifyRemoteFetch(bundle);
         }
 
-        if (!isForeground) {
-            Log.v(LOG_TAG, "sendNotification: " + bundle);
+        Log.v(LOG_TAG, "sendNotification: " + bundle);
 
+        if (!isForeground) {
             Application applicationContext = (Application) context.getApplicationContext();
             RNPushNotificationHelper pushNotificationHelper = new RNPushNotificationHelper(applicationContext);
             pushNotificationHelper.sendToNotificationCentre(bundle);
+        } else {
+            jsDelivery.notifyNotification(bundle);
         }
     }
 

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
@@ -70,7 +70,9 @@ public class RNPushNotificationListenerService extends FirebaseMessagingService 
             }
         }
 
-        Log.v(LOG_TAG, "onMessageReceived: " + bundle);
+        if (!bundle.containsKey("message") && bundle.containsKey("body")) {
+            bundle.putString("message", bundle.getString("body"));
+        }
 
         // We need to run this on the main thread, as the React code assumes that is true.
         // Namely, DevServerHelper constructs a Handler() without a Looper, which triggers:
@@ -111,9 +113,9 @@ public class RNPushNotificationListenerService extends FirebaseMessagingService 
     private void handleRemotePushNotification(ReactApplicationContext context, Bundle bundle) {
 
         // If notification ID is not provided by the user for push notification, generate one at random
-        if (bundle.getString("id") == null) {
+        if (bundle.getString("notificationId") == null) {
             Random randomNumberGenerator = new Random(System.currentTimeMillis());
-            bundle.putString("id", String.valueOf(randomNumberGenerator.nextInt()));
+            bundle.putString("notificationId", String.valueOf(randomNumberGenerator.nextInt()));
         }
 
         Boolean isForeground = isApplicationInForeground();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-push-notification",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "React Native Local and Remote Notifications",
   "main": "index",
   "scripts": {


### PR DESCRIPTION
This PR includes the following:

- Adds support to a custom NotificationChannelID from the app manifest
- Adds support to a custom NotificationIcon from the app manifest
- Create the NotificationChannel right when the app launches. The reason of this change is because the NotificationChannel were created **ONLY** when a notification was received or created locally while the app was **open**, so if you close the app, and then receive your first notification, the OS will create a generic notification on its own with the notificationChannelID you set as default for the firebase settings.
- Update README to explain how these changes can be used, and includes also the firebase default settings
- Prevent sending the notification to NotificationCentre when the app is in foreground