### PR TITLE
Update react-native.config.js

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,7 +1,9 @@
 module.exports = {
-    project: {
-      android: {
-        "packageInstance": "new ReactNativePushNotificationPackage()"
-      } 
+    dependency: {
+        platforms: {
+            android: {
+                "packageInstance": "new ReactNativePushNotificationPackage()"
+            } 
+        }
     }
 };


### PR DESCRIPTION
Add proper dependency tag to react-native.config.js. Looking at how other repositories handle the update from `rnpm` to `react-native.config.js`, this is the right way to do it.