### PR TITLE
Add PushNotificationIOS installation instruction link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Changelog is available from version 3.1.3 here: [Changelog](https://github.com/z
 
 `react-native link react-native-push-notification`
 
+If you target iOS you also need to follow the [installation instructions for PushNotificationIOS](https://github.com/react-native-community/react-native-push-notification-ios) since this package depends on it.
+
 **NOTE: For Android, you will still have to manually update the AndroidManifest.xml (as below) in order to use Scheduled Notifications.**
 
 ## Issues


### PR DESCRIPTION
I believe this would be helpful since, from what I can tell, auto linking will not work without doing this.