### PR TITLE
fixed breaking android x compatibility regression

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,15 +43,11 @@ android {
 }
 
 dependencies {
-    def supportLibVersion = project.hasProperty('supportLibVersion') ? project.supportLibVersion : DEFAULT_SUPPORT_LIB_VERSION
-    def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
-    def firebaseVersion = project.hasProperty('firebaseVersion') ? project.firebaseVersion : DEFAULT_FIREBASE_MESSAGING_VERSION
-
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     testImplementation 'junit:junit:4.12'
-    implementation "com.android.support:appcompat-v7:$supportLibVersion"
+    implementation "androidx.appcompat:appcompat:1.0.0"
     implementation 'com.facebook.react:react-native:+'
-    implementation "com.google.android.gms:play-services-gcm:$googlePlayServicesVersion"
+    implementation "com.google.android.gms:play-services-gcm:${safeExtGet('googlePlayServicesVersion', '+')}"
     implementation 'me.leolin:ShortcutBadger:1.1.8@aar'
-    implementation "com.google.firebase:firebase-messaging:$firebaseVersion"
+    implementation "com.google.firebase:firebase-messaging:${safeExtGet('firebaseVersion', '+')}"
 }


### PR DESCRIPTION
This fixes a regression that broke android builds on 3.1.8.
This was the initial commit for adding androidx support https://github.com/zo0r/react-native-push-notification/pull/1095. It was overwritten by this commit with the regression: https://github.com/zo0r/react-native-push-notification/commit/746190c05451a1c49f66bb92296f65158806c9d1