### PR TITLE
Fix undefined fallback variables in build gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,9 +43,9 @@ android {
 }
 
 dependencies {
-    def supportLibVersion = project.hasProperty('supportLibVersion') ? project.supportLibVersion : DEFAULT_SUPPORT_LIB_VERSION
-    def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
-    def firebaseVersion = project.hasProperty('firebaseVersion') ? project.firebaseVersion : DEFAULT_FIREBASE_MESSAGING_VERSION
+    def supportLibVersion = safeExtGet('supportLibVersion', '27.1.1')
+    def googlePlayServicesVersion = safeExtGet('googlePlayServicesVersion', '+')
+    def firebaseVersion = safeExtGet('firebaseVersion', '+')
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
The fallback variables defined in the build gradle are all undefined
DEFAULT_SUPPORT_LIB_VERSION
DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
DEFAULT_FIREBASE_MESSAGING_VERSION

Edit: not sure why there were downvotes on this, so I have provided a little more clarification.

https://github.com/zo0r/react-native-push-notification/commit/acfa3bf15308e3d7bc7f7ced76c7a11e932d7314

This particular commit Refractors the hard coded variables to the safeGet method fallback, but it seems like the variables above were missed or the changes lost in a merge conflict, this PR fixes this issue and ensures android builds correctly.