### PR TITLE
Added handler for PushNotificationIOS 'registrationError' event

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,9 +78,11 @@ Notifications.configure = function(options: Object) {
 
 	if ( this.isLoaded === false ) {
 		this._onRegister = this._onRegister.bind(this);
+		this._onRegistrationError = this._onRegistrationError.bind(this);
 		this._onNotification = this._onNotification.bind(this);
 		this._onRemoteFetch = this._onRemoteFetch.bind(this);
 		this.callNative( 'addEventListener', [ 'register', this._onRegister ] );
+		this.callNative('addEventListener', ['registrationError', this._onRegistrationError]);
 		this.callNative( 'addEventListener', [ 'notification', this._onNotification ] );
 		this.callNative( 'addEventListener', [ 'localNotification', this._onNotification ] );
 		Platform.OS === 'android' ? this.callNative( 'addEventListener', [ 'remoteFetch', this._onRemoteFetch ] ) : null
@@ -107,6 +109,7 @@ Notifications.configure = function(options: Object) {
 /* Unregister */
 Notifications.unregister = function() {
 	this.callNative( 'removeEventListener', [ 'register', this._onRegister ] )
+	this.callNative( 'removeEventListener', [ 'registrationError', this._onRegistrationError ] )
 	this.callNative( 'removeEventListener', [ 'notification', this._onNotification ] )
 	this.callNative( 'removeEventListener', [ 'localNotification', this._onNotification ] )
 	Platform.OS === 'android' ? this.callNative( 'removeEventListener', [ 'remoteFetch', this._onRemoteFetch ] ) : null
@@ -199,6 +202,12 @@ Notifications._onRegister = function(token: String) {
 			os: Platform.OS
 		});
 	}
+};
+
+Notifications._onRegistrationError = function(error: Object) {
+  if (this.onError !== false) {
+    this.onError(error);
+  }
 };
 
 Notifications._onRemoteFetch = function(notificationData: Object) {


### PR DESCRIPTION
It's very important to have the ability to define onError function inside PushNotification.configure. 

```js
PushNotification.configure({

  …

  onError: error => {
    console.log(error);
  },

  …

});
```

In my case, I had to know why notifications didn't work, onError helped me to understand that "remote notifications are not supported in the simulator".