### PR TITLE
Rename firebaseVersion to firebaseMessagingVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,7 +45,7 @@ android {
 dependencies {
     def supportLibVersion = safeExtGet('supportLibVersion', '27.1.1')
     def googlePlayServicesVersion = safeExtGet('googlePlayServicesVersion', '+')
-    def firebaseVersion = safeExtGet('firebaseVersion', '+')
+    def firebaseMessagingVersion = safeExtGet('firebaseMessagingVersion', '+')
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     testImplementation 'junit:junit:4.12'
@@ -53,5 +53,5 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation "com.google.android.gms:play-services-gcm:$googlePlayServicesVersion"
     implementation 'me.leolin:ShortcutBadger:1.1.8@aar'
-    implementation "com.google.firebase:firebase-messaging:$firebaseVersion"
+    implementation "com.google.firebase:firebase-messaging:$firebaseMessagingVersion"
 }


### PR DESCRIPTION
This name for this constant is not correct.

`firebaseVersion` should be used for firebase-core. This create conflicts with others libraries because if I want to use 16.+ in core, I can't, because doesn't exists firebase-messaging v16 ( [check versions](https://mvnrepository.com/artifact/com.google.firebase/firebase-messaging) ).

So the correct name for this is `firebaseMessagingVersion` .