### PR TITLE
[Android] send data object along with notification

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
@@ -31,7 +31,6 @@ public class RNPushNotificationListenerService extends FirebaseMessagingService 
     public void onMessageReceived(RemoteMessage message) {
         String from = message.getFrom();
         RemoteMessage.Notification remoteNotification = message.getNotification();
-
         final Bundle bundle = new Bundle();
         // Putting it from remoteNotification first so it can be overriden if message
         // data has it
@@ -39,16 +38,17 @@ public class RNPushNotificationListenerService extends FirebaseMessagingService 
             // ^ It's null when message is from GCM
             bundle.putString("title", remoteNotification.getTitle());
             bundle.putString("message", remoteNotification.getBody());
+            bundle.putString("sound", remoteNotification.getSound());
+            bundle.putString("color", remoteNotification.getColor());
         }
 
-        for(Map.Entry<String, String> entry : message.getData().entrySet()) {
-            bundle.putString(entry.getKey(), entry.getValue());
-        }
-        JSONObject data = getPushData(bundle.getString("data"));
+        Map<String, String> notificationData = message.getData();
+
         // Copy `twi_body` to `message` to support Twilio
-        if (bundle.containsKey("twi_body")) {
-            bundle.putString("message", bundle.getString("twi_body"));
+        if (notificationData.containsKey("twi_body")) {
+            bundle.putString("message", notificationData.get("twi_body"));
         }
+        JSONObject data = getPushData(notificationData.get("data"));
 
         if (data != null) {
             if (!bundle.containsKey("message")) {
@@ -69,6 +69,12 @@ public class RNPushNotificationListenerService extends FirebaseMessagingService 
                 ApplicationBadgeHelper.INSTANCE.setApplicationIconBadgeNumber(this, badge);
             }
         }
+
+        Bundle dataBundle = new Bundle();
+        for(Map.Entry<String, String> entry : notificationData.entrySet()) {
+            dataBundle.putString(entry.getKey(), entry.getValue());
+        }
+        bundle.putParcelable("data", dataBundle);
 
         Log.v(LOG_TAG, "onMessageReceived: " + bundle);
 


### PR DESCRIPTION
I got an issue with FCM notification that there is no `data` property in notification data when receiving notification.

```
{
    foreground: false, // BOOLEAN: If the notification was received in foreground or not
    userInteraction: false, // BOOLEAN: If the notification was opened by the user from the notification area or not
    message: 'My Notification Message', // STRING: The notification message
    data: {}, // OBJECT: The push data
}
```

This PR will send data via `onNotification` with `data` property.