### PR TITLE
fix: Remove fishy reference from android project files

### DIFF
--- a/android/react-native-push-notification.iml
+++ b/android/react-native-push-notification.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":react-native-push-notification" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/../../january.ai/januarychallenge/android" external.system.id="GRADLE" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":react-native-push-notification" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/../../../android" external.system.id="GRADLE" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="android-gradle" name="Android-Gradle">
       <configuration>


### PR DESCRIPTION
Addresses issue: https://github.com/zo0r/react-native-push-notification/issues/1169

Somehow a reference to a `january.ai` project found its way into the project, breaking android studio builds. This PR removes it.