### PR TITLE
Update push-notification-ios to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "git+ssh://git@github.com:zo0r/react-native-push-notification.git"
   },
   "dependencies": {
-    "@react-native-community/push-notification-ios": "^1.0.1"
+    "@react-native-community/push-notification-ios": "^1.2.0"
   },
   "peerDependencies": {
     "react-native": ">=0.33"


### PR DESCRIPTION
Version 1.1.0 giving a `No known class method for selector 'didReceiveNotificationResponse'`error