### PR TITLE
Added Abandon Permissions method to Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,11 @@ Removes the specified notifications from Notification Center
 | ----------- | ----- | -------- | ---------------------------------- |
 | identifiers | array | Yes      | Array of notification identifiers. |
 
+
+## Abandon Permissions
+
+`PushNotification.abandonPermissions()` Revokes the current token and unregister for all remote notifications received via APNS or FCM.
+
 ## Notification priority
 
 (optional) Specify `priority` to set priority of notification. Default value: "high"
@@ -537,12 +542,6 @@ Same parameters as `PushNotification.localNotification()`
 - `badge`: boolean
 - `sound`: boolean
 
-## Revoke Token
-
-`PushNotification.revokeToken()` Revokes the current token. Useful on logout cases and multi users at same device
-
 ## iOS Only Methods
 
 `PushNotification.getApplicationIconBadgeNumber(callback: Function)` Get badge number
-
-`PushNotification.abandonPermissions()` Unregister for all remote notifications received via Apple Push Notification service.

--- a/README.md
+++ b/README.md
@@ -537,6 +537,10 @@ Same parameters as `PushNotification.localNotification()`
 - `badge`: boolean
 - `sound`: boolean
 
+## Revoke Token
+
+`PushNotification.revokeToken()` Revokes the current token. Useful on logout cases and multi users at same device
+
 ## iOS Only Methods
 
 `PushNotification.getApplicationIconBadgeNumber(callback: Function)` Get badge number

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -25,6 +25,7 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
@@ -261,10 +262,9 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
 
     @ReactMethod
     /**
-     * Revokes the current token. Useful on logout cases and multi users at
-     * same device
+     * Unregister for all remote notifications received
      */
-    public void revokeToken() {
+    public void abandonPermissions() {
       try {
         FirebaseInstanceId.getInstance().deleteInstanceId();
       } catch (IOException e) {

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -258,4 +258,18 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
     public void removeDeliveredNotifications(ReadableArray identifiers) {
       mRNPushNotificationHelper.clearDeliveredNotifications(identifiers);
     }
+
+    @ReactMethod
+    /**
+     * Revokes the current token. Useful on logout cases and multi users at
+     * same device
+     */
+    public void revokeToken() {
+      try {
+        FirebaseInstanceId.getInstance().deleteInstanceId();
+      } catch (IOException e) {
+        Log.e(LOG_TAG, "exception", e);
+        return;
+      }
+    }
 }

--- a/component/index.android.js
+++ b/component/index.android.js
@@ -131,6 +131,10 @@ NotificationsComponent.prototype.removeDeliveredNotifications = function(identif
   RNPushNotification.removeDeliveredNotifications(identifiers);
 }
 
+NotificationsComponent.prototype.revokeToken = function() {
+	RNPushNotification.revokeToken();
+}
+
 module.exports = {
 	state: false,
 	component: new NotificationsComponent()

--- a/component/index.android.js
+++ b/component/index.android.js
@@ -61,10 +61,6 @@ NotificationsComponent.prototype.setApplicationIconBadgeNumber = function(number
        RNPushNotification.setApplicationIconBadgeNumber(number);
 };
 
-NotificationsComponent.prototype.abandonPermissions = function() {
-	/* Void */
-};
-
 NotificationsComponent.prototype.checkPermissions = function(callback) {
 	RNPushNotification.checkPermissions().then(alert => callback({ alert }));
 };
@@ -131,8 +127,8 @@ NotificationsComponent.prototype.removeDeliveredNotifications = function(identif
   RNPushNotification.removeDeliveredNotifications(identifiers);
 }
 
-NotificationsComponent.prototype.revokeToken = function() {
-	RNPushNotification.revokeToken();
+NotificationsComponent.prototype.abandonPermissions = function() {
+	RNPushNotification.abandonPermissions();
 }
 
 module.exports = {

--- a/example/App.js
+++ b/example/App.js
@@ -84,6 +84,17 @@ export default class App extends Component {
           }}>
           <Text>Request Permissions</Text>
         </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.button}
+          onPress={() => {
+            this.notif.revokeToken();
+            Alert.alert(
+              'Revoke Token',
+              'Token has been revoked. Reload the app to register again with a new token.'
+            );
+          }}>
+          <Text>Revoke Token</Text>
+        </TouchableOpacity>
 
         <View style={styles.spacer}></View>
 

--- a/example/App.js
+++ b/example/App.js
@@ -87,13 +87,13 @@ export default class App extends Component {
         <TouchableOpacity
           style={styles.button}
           onPress={() => {
-            this.notif.revokeToken();
+            this.notif.abandonPermissions();
             Alert.alert(
-              'Revoke Token',
-              'Token has been revoked. Reload the app to register again with a new token.'
+              'Abandon Permissions',
+              'Reload the app to register again with a new token'
             );
           }}>
-          <Text>Revoke Token</Text>
+          <Text>Abandon Permissions</Text>
         </TouchableOpacity>
 
         <View style={styles.spacer}></View>

--- a/example/NotifService.js
+++ b/example/NotifService.js
@@ -116,4 +116,8 @@ export default class NotifService {
   cancelAll() {
     PushNotification.cancelAllLocalNotifications();
   }
+
+  revokeToken() {
+    PushNotification.revokeToken();
+  }
 }

--- a/example/NotifService.js
+++ b/example/NotifService.js
@@ -117,7 +117,7 @@ export default class NotifService {
     PushNotification.cancelAllLocalNotifications();
   }
 
-  revokeToken() {
-    PushNotification.revokeToken();
+  abandonPermissions() {
+    PushNotification.abandonPermissions();
   }
 }

--- a/index.js
+++ b/index.js
@@ -188,9 +188,9 @@ Notifications.localNotificationSchedule = function(details) {
 	}
 };
 
-/* Revoke Token */
-Notifications.revokeToken = function() {
-	this.handler.revokeToken();
+/* Abandon Permissions */
+Notifications.abandonPermissions = function() {
+	this.handler.abandonPermissions();
 }
 
 /* Internal Functions */
@@ -318,10 +318,6 @@ Notifications.popInitialNotification = function(handler) {
 	this.callNative('getInitialNotification').then(function(result){
 		handler(result);
 	});
-};
-
-Notifications.abandonPermissions = function() {
-	return this.callNative('abandonPermissions', arguments);
 };
 
 Notifications.checkPermissions = function() {

--- a/index.js
+++ b/index.js
@@ -188,6 +188,11 @@ Notifications.localNotificationSchedule = function(details) {
 	}
 };
 
+/* Revoke Token */
+Notifications.revokeToken = function() {
+	this.handler.revokeToken();
+}
+
 /* Internal Functions */
 Notifications._onRegister = function(token) {
 	if ( this.onRegister !== false ) {


### PR DESCRIPTION
The Abandon Permissions method makes possible to revoke the current token, generating a new one on registration.

Unregister for all remote notifications received via APNS or FCM.

In case many users could be using the same device, Revoke Token will be useful to prevent notifications to the previous user from the device, using it in a logout action for example.

Fixes #864 