### PR TITLE
Add missing push timestamp for Android 7+

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -265,6 +265,12 @@ public class RNPushNotificationHelper {
                     .setPriority(priority)
                     .setAutoCancel(bundle.getBoolean("autoCancel", true));
             
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) { // API 24 and higher
+                // Restore showing timestamp on Android 7+
+                // Source: https://developer.android.com/reference/android/app/Notification.Builder.html#setShowWhen(boolean)
+                notification.setShowWhen(true);
+            }
+
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) { // API 26 and higher
                 // Changing Default mode of notification
                 notification.setDefaults(Notification.DEFAULT_LIGHTS);


### PR DESCRIPTION
I noticed that push notifications received on Android do not show sent date timestamps. 
According to [official docs](https://developer.android.com/reference/android/app/Notification.Builder.html#setShowWhen\(boolean\)) it's off for Android 7 and higher.

Here is example:
![](https://cloud.githubusercontent.com/assets/6304/26124018/d205ef0c-3a31-11e7-9de5-c31536c66736.png)

This PR enables it by default for every Android version.