### PR TITLE
Add notification id to iOS if userInfo doesn't exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,6 +160,8 @@ Notifications.localNotification = function(details) {
 
     if (details.userInfo) {
       details.userInfo.id = details.userInfo.id || details.id;
+    } else {
+      details.userInfo = {id: details.id};
     }
 
     // for valid fields see: https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html
@@ -228,6 +230,8 @@ Notifications.localNotificationSchedule = function(details) {
 
     if (details.userInfo) {
       details.userInfo.id = details.userInfo.id || details.id;
+    } else {
+      details.userInfo = {id: details.id};
     }
 
     const iosDetails = {


### PR DESCRIPTION
Currently we add notification `id` variable to notification object on iOS only if `userInfo` exists. 

If `userInfo` is not set, `id` is not being set. 

This PR fixes that.

Cheers 🍻 