### PR TITLE
Return a Promise on getScheduledLocalNotifications

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -108,7 +108,7 @@ export default class App extends Component {
         <TouchableOpacity
           style={styles.button}
           onPress={() => {
-            this.notif.getScheduledLocalNotifications(notifs => console.log(notifs));
+            this.notif.getScheduledLocalNotifications().then(notifs => console.log(notifs));
           }}>
           <Text>Console.Log Scheduled Local Notifications</Text>
         </TouchableOpacity>

--- a/index.js
+++ b/index.js
@@ -452,40 +452,46 @@ Notifications.getDeliveredNotifications = function() {
   return this.callNative('getDeliveredNotifications', arguments);
 }
 
-Notifications.getScheduledLocalNotifications = function(callback) {
-	const mapNotifications = (notifications) => {
-		let mappedNotifications = [];
-		if(notifications?.length > 0) {
-			if(Platform.OS === 'ios'){
-				mappedNotifications = notifications.map(notif => {
-					return ({
-						soundName: notif.soundName,
-						repeatInterval: notif.repeatInterval,
-						id: notif.userInfo?.id,
-						date: new Date(notif.fireDate),
-						number: notif?.applicationIconBadgeNumber,
-						message: notif?.alertBody,
-						title: notif?.alertTitle,
-					})
-				})
-			} else if(Platform.OS === 'android') {
-				mappedNotifications = notifications.map(notif => {
-					return ({
-						soundName: notif.soundName,
-						repeatInterval: notif.repeatInterval,
-						id: notif.id,
-						date: new Date(notif.date),
-						number: notif.number,
-						message: notif.message,
-						title: notif.title,
-					})
-				})
-			}
-		}
-		callback(mappedNotifications);
-	}
-
-	return this.callNative('getScheduledLocalNotifications', [mapNotifications]);
+Notifications.getScheduledLocalNotifications = function() {
+  return new Promise((resolve, reject) => {
+    const mapNotifications = (notifications) => {
+      let mappedNotifications = [];
+      if(notifications?.length > 0) {
+        if(Platform.OS === 'ios'){
+          mappedNotifications = notifications.map(notif => {
+            console.tron.log(notif);
+            return ({
+              soundName: notif.soundName,
+              repeatInterval: notif.repeatInterval,
+              id: notif.userInfo?.id,
+              date: new Date(notif.fireDate),
+              number: notif?.applicationIconBadgeNumber,
+              message: notif?.alertBody,
+              title: notif?.alertTitle,
+            })
+          })
+        } else if(Platform.OS === 'android') {
+          mappedNotifications = notifications.map(notif => {
+            return ({
+              soundName: notif.soundName,
+              repeatInterval: notif.repeatInterval,
+              id: notif.id,
+              date: new Date(notif.date),
+              number: notif.number,
+              message: notif.message,
+              title: notif.title,
+            })
+          })
+        }
+      }
+      resolve(mappedNotifications);
+    }
+    try{
+      this.callNative('getScheduledLocalNotifications', [mapNotifications]);
+    } catch(e) {
+      reject(e);
+    }
+  })
 }
 
 Notifications.removeDeliveredNotifications = function() {


### PR DESCRIPTION
I've noticed that current concept of passing callback to the `getScheduledLocalNotifications` function as an argument wasn't very smart or user friendly, and a nightmare in redux sagas.

Returning a promise keeps it way more simple.

Correct me if I'm wrong @Dallas62 