### PR TITLE
Add function createChannel for custom Android channel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,23 @@ In the location notification json specify the full file name:
 
 ## Channel Management (Android)
 
-This library doesn't include a full Channel Management at the moment. Channels are generated on the fly when you pass options to `PushNotification.localNotification` or `PushNotification.localNotificationSchedule`.
+To use custom channels, create them at startup and pass the matching `channelId` through to `PushNotification.localNotification`
+
+```javascript
+  PushNotification.createChannel(
+    {
+      channelId: "custom-channel-id", // (required)
+      channelName: "Custom channel", // (required)
+      channelDesc: "A custom channel to categorise your custom notifications", // (optional) default: undefined.
+      soundName: "default", // (optional) See `soundName` parameter of `localNotification` function
+      importance: 4, // (optional) default: 4. Int value of the Android notification importance
+      vibrate: true, // (optional) default: true. Creates the default vibration patten if true.
+    },
+    (created: any) => console.log(`createChannel returned '${created}'`) // (optional) callback returns whether the channel was created, false means it already existed.
+  );
+```
+
+Channels with ids that do not exist are generated on the fly when you pass options to `PushNotification.localNotification` or `PushNotification.localNotificationSchedule`.
 
 The pattern of `channel_id` is:
 

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -299,6 +299,18 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
 
     @ReactMethod
     /**
+     * Creates a channel if it does not already exist. Returns whether the channel was created.
+     */
+    public void createChannel(ReadableMap channelInfo, Callback callback) {
+      boolean created = mRNPushNotificationHelper.createChannel(channelInfo);
+
+      if(callback != null) {
+        callback.invoke(created);
+      }
+    }
+
+    @ReactMethod
+    /**
      * Check if channel is blocked with a given id
      */
     public void channelBlocked(String channel_id, Callback callback) {

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -952,7 +952,7 @@ public class RNPushNotificationHelper {
         String channelDesc = channelInfo.hasKey("channelDesc") ? channelInfo.getString("channelDesc") : null;
         String soundName = channelInfo.hasKey("soundName") ? channelInfo.getString("soundName") : "default";
         int importance = channelInfo.hasKey("importance") ? channelInfo.getInt("importance") : 4;
-        boolean vibrate = channelInfo.hasKey("importance") && channelInfo.getBoolean("vibrate");
+        boolean vibrate = channelInfo.hasKey("vibrate") && channelInfo.getBoolean("vibrate");
         long[] vibratePattern = vibrate ? new long[] { DEFAULT_VIBRATION } : null;
 
         NotificationManager manager = notificationManager();

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -428,30 +428,12 @@ public class RNPushNotificationHelper {
             Uri soundUri = null;
 
             if (!bundle.containsKey("playSound") || bundle.getBoolean("playSound")) {
-                soundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
-
                 String soundName = bundle.getString("soundName");
-
-                if (soundName != null) {
-                    if (!"default".equalsIgnoreCase(soundName)) {
-
-                        // sound name can be full filename, or just the resource name.
-                        // So the strings 'my_sound.mp3' AND 'my_sound' are accepted
-                        // The reason is to make the iOS and android javascript interfaces compatible
-
-                        int resId;
-                        if (context.getResources().getIdentifier(soundName, "raw", context.getPackageName()) != 0) {
-                            resId = context.getResources().getIdentifier(soundName, "raw", context.getPackageName());
-                        } else {
-                            soundName = soundName.substring(0, soundName.lastIndexOf('.'));
-                            resId = context.getResources().getIdentifier(soundName, "raw", context.getPackageName());
-                        }
-
-                        soundUri = Uri.parse("android.resource://" + context.getPackageName() + "/" + resId);
-                    }
-                } else {
+                if (soundName == null) {
                     soundName = "default";
                 }
+
+                soundUri = getSoundUri(soundName);
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) { // API 26 and higher
                     channel_id = channel_id + "-" + soundName;
@@ -673,6 +655,27 @@ public class RNPushNotificationHelper {
                 bundle.putDouble("fireDate", newFireDate);
                 this.sendNotificationScheduled(bundle);
             }
+        }
+    }
+
+    private Uri getSoundUri(String soundName) {
+        if (soundName == null || "default".equalsIgnoreCase(soundName)) {
+            return RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
+        } else {
+
+            // sound name can be full filename, or just the resource name.
+            // So the strings 'my_sound.mp3' AND 'my_sound' are accepted
+            // The reason is to make the iOS and android javascript interfaces compatible
+
+            int resId;
+            if (context.getResources().getIdentifier(soundName, "raw", context.getPackageName()) != 0) {
+                resId = context.getResources().getIdentifier(soundName, "raw", context.getPackageName());
+            } else {
+                soundName = soundName.substring(0, soundName.lastIndexOf('.'));
+                resId = context.getResources().getIdentifier(soundName, "raw", context.getPackageName());
+            }
+
+            return Uri.parse("android.resource://" + context.getPackageName() + "/" + resId);
         }
     }
 
@@ -899,11 +902,11 @@ public class RNPushNotificationHelper {
         manager.deleteNotificationChannel(channel_id);
     }
 
-    private void checkOrCreateChannel(NotificationManager manager, String channel_id, String channel_name, String channel_description, Uri soundUri, int importance, long[] vibratePattern) {
+    private boolean checkOrCreateChannel(NotificationManager manager, String channel_id, String channel_name, String channel_description, Uri soundUri, int importance, long[] vibratePattern) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
-            return;
+            return false;
         if (manager == null)
-            return;
+            return false;
 
         NotificationChannel channel = manager.getNotificationChannel(channel_id);
 
@@ -920,7 +923,7 @@ public class RNPushNotificationHelper {
 
             channel.setDescription(channel_description);
             channel.enableLights(true);
-            channel.enableVibration(true);
+            channel.enableVibration(vibratePattern != null);
             channel.setVibrationPattern(vibratePattern);
 
             if (soundUri != null) {
@@ -935,7 +938,28 @@ public class RNPushNotificationHelper {
             }
 
             manager.createNotificationChannel(channel);
+            return true;
         }
+        return false;
+    }
+
+    public boolean createChannel(ReadableMap channelInfo) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
+            return false;
+
+        String channelId = channelInfo.getString("channelId");
+        String channelName = channelInfo.getString("channelName");
+        String channelDesc = channelInfo.hasKey("channelDesc") ? channelInfo.getString("channelDesc") : null;
+        String soundName = channelInfo.hasKey("soundName") ? channelInfo.getString("soundName") : "default";
+        int importance = channelInfo.hasKey("importance") ? channelInfo.getInt("importance") : 4;
+        boolean vibrate = channelInfo.hasKey("importance") && channelInfo.getBoolean("vibrate");
+        long[] vibratePattern = vibrate ? new long[] { DEFAULT_VIBRATION } : null;
+
+        NotificationManager manager = notificationManager();
+
+        Uri soundUri = getSoundUri(soundName);
+
+        return checkOrCreateChannel(manager, channelId, channelName, channelDesc, soundUri, importance, vibratePattern);
     }
     
     public boolean isApplicationInForeground(Context context) {

--- a/component/index.android.js
+++ b/component/index.android.js
@@ -154,6 +154,10 @@ NotificationsComponent.prototype.channelExists = function(channel_id, callback) 
 	RNPushNotification.channelExists(channel_id, callback);
 }
 
+NotificationsComponent.prototype.createChannel = function(channelInfo, callback) {
+	RNPushNotification.createChannel(channelInfo, callback);
+}
+
 NotificationsComponent.prototype.channelBlocked = function(channel_id, callback) {
 	RNPushNotification.channelBlocked(channel_id, callback);
 }

--- a/index.js
+++ b/index.js
@@ -513,6 +513,10 @@ Notifications.channelExists = function() {
   return this.callNative('channelExists', arguments);
 };
 
+Notifications.createChannel = function() {
+  return this.callNative('createChannel', arguments);
+};
+
 Notifications.channelBlocked = function() {
   return this.callNative('channelBlocked', arguments);
 };


### PR DESCRIPTION
The rationale behind this PR is that the current functionality with default channel names does not look very professional the end user. Apps can use this new function along with the Manifest setting to disable default channel creation to have fully customised channels.

This has had a fair bit of internal testing and the app using it will be updated for the public soon. I realised after doing this that the `importance` parameter should have used the string mappings already existing, but I don't have time to update that at the moment. Also the typings have not been updated.