### PR TITLE
Add Android messageId to enable integration with react-native-firebase/messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ PushNotification.localNotification({
   ignoreInForeground: false, // (optional) if true, the notification will not be visible when the app is in the foreground (useful for parity with how iOS notifications appear)
   shortcutId: "shortcut-id", // (optional) If this notification is duplicative of a Launcher shortcut, sets the id of the shortcut, in case the Launcher wants to hide the shortcut, default undefined
   channelId: "your-custom-channel-id", // (optional) custom channelId, if the channel doesn't exist, it will be created with options passed above (importance, vibration, sound). Once the channel is created, the channel will not be update. Make sure your channelId is different if you change these options. If you have created a custom channel, it will apply options of the channel.
+  messageId: "google:message_id", // (optional) added as `message_id` to intent extras so opening push notification can find data stored by @react-native-firebase/messaging module. 
 
   actions: '["Yes", "No"]', // (Android only) See the doc for notification actions to know more
   invokeApp: true, // (optional) This enable click on actions to bring back the application to foreground or stay in background, default: true

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -425,6 +425,12 @@ public class RNPushNotificationHelper {
             bundle.putBoolean("userInteraction", true);
             intent.putExtra("notification", bundle);
 
+            // Add message_id to intent so react-native-firebase/messaging can identify it
+            String messageId = bundle.getString("messageId");
+            if (messageId != null) {
+                intent.putExtra("message_id", messageId);
+            }
+
             Uri soundUri = null;
 
             if (!bundle.containsKey("playSound") || bundle.getBoolean("playSound")) {
@@ -557,6 +563,9 @@ public class RNPushNotificationHelper {
                     bundle.putString("action", action);
                     actionIntent.putExtra("notification", bundle);
                     actionIntent.setPackage(packageName);
+                    if (messageId != null) {
+                        intent.putExtra("message_id", messageId);
+                    }
 
                     PendingIntent pendingActionIntent = PendingIntent.getBroadcast(context, notificationID, actionIntent,
                             PendingIntent.FLAG_UPDATE_CURRENT);


### PR DESCRIPTION
This PR is part of the solution to the following problem:
- Using `@react-native-firebase/messaging` for delivery and handling or remote messages and notifications when the app is killed or in the background
- Using `react-native-push-notification` to display these notifications when the app is in the foreground
- Tapping on a push that arrived in the foreground opens the app but does _not_ send the payload through to RN firebase `messaging().getInitialNotification` or `messaging().onNotificationOpenedApp`

RN firebase messaging stores the remote notification payload and looks it up based on this "message_id" intent extra. The full solution requires minor changes to RN firebase too, which will be submitted as another PR soon.