### PR TITLE
Support empty strings as default push notification icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,9 +295,9 @@ PushNotification.localNotification({
   ticker: "My Notification Ticker", // (optional)
   showWhen: true, // (optional) default: true
   autoCancel: true, // (optional) default: true
-  largeIcon: "ic_launcher", // (optional) default: "ic_launcher"
+  largeIcon: "ic_launcher", // (optional) default: "ic_launcher". Use "" for no large icon.
   largeIconUrl: "https://www.example.tld/picture.jpg", // (optional) default: undefined
-  smallIcon: "ic_notification", // (optional) default: "ic_notification" with fallback for "ic_launcher"
+  smallIcon: "ic_notification", // (optional) default: "ic_notification" with fallback for "ic_launcher". Use "" for default small icon.
   bigText: "My big text that will be shown when notification is expanded", // (optional) default: "message" prop
   subText: "This is a subText", // (optional) default: none
   bigPictureUrl: "https://www.example.tld/picture.jpg", // (optional) default: undefined

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -348,13 +348,13 @@ public class RNPushNotificationHelper {
             }
 
             // Small icon
-            int smallIconResId;
+            int smallIconResId = 0;
 
             String smallIcon = bundle.getString("smallIcon");
 
             if (smallIcon != null) {
                 smallIconResId = res.getIdentifier(smallIcon, "mipmap", packageName);
-            } else {
+            } else if (!smallIcon.isEmpty()) {
                 smallIconResId = res.getIdentifier("ic_notification", "mipmap", packageName);
             }
 
@@ -370,13 +370,13 @@ public class RNPushNotificationHelper {
 
             // Large icon
             if(largeIconBitmap == null) {
-                int largeIconResId;
+                int largeIconResId = 0;
 
                 String largeIcon = bundle.getString("largeIcon");
 
                 if (largeIcon != null) {
                     largeIconResId = res.getIdentifier(largeIcon, "mipmap", packageName);
-                } else {
+                } else if (!largeIcon.isEmpty()) {
                     largeIconResId = res.getIdentifier("ic_launcher", "mipmap", packageName);
                 }
 


### PR DESCRIPTION
The reason for this PR as that when using `@react-native-firebase/messaging`, background notifications show up with different icons to `react-native-push-notication`. For backwards compatibility, I've added support for empty strings causes no icon customisation on the native notification, which mimics behaviour of the RN firebase messaging module.