### PR TITLE
[ANDROID] Add support for setOnlyAlertOnce property

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,8 @@ PushNotification.localNotification({
   ignoreInForeground: false, // (optional) if true, the notification will not be visible when the app is in the foreground (useful for parity with how iOS notifications appear)
   shortcutId: "shortcut-id", // (optional) If this notification is duplicative of a Launcher shortcut, sets the id of the shortcut, in case the Launcher wants to hide the shortcut, default undefined
   channelId: "your-custom-channel-id", // (optional) custom channelId, if the channel doesn't exist, it will be created with options passed above (importance, vibration, sound). Once the channel is created, the channel will not be update. Make sure your channelId is different if you change these options. If you have created a custom channel, it will apply options of the channel.
-
+  onlyAlertOnce: false, //(optional) alert will open only once with sound and notify, default: false
+  
   actions: '["Yes", "No"]', // (Android only) See the doc for notification actions to know more
   invokeApp: true, // (optional) This enable click on actions to bring back the application to foreground or stay in background, default: true
 

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -314,7 +314,8 @@ public class RNPushNotificationHelper {
                     .setTicker(bundle.getString("ticker"))
                     .setVisibility(visibility)
                     .setPriority(priority)
-                    .setAutoCancel(bundle.getBoolean("autoCancel", true));
+                    .setAutoCancel(bundle.getBoolean("autoCancel", true))
+                    .setOnlyAlertOnce(bundle.getBoolean("onlyAlertOnce", false));
             
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) { // API 24 and higher
                 // Restore showing timestamp on Android 7+


### PR DESCRIPTION
Add support for setOnlyAlertOnce property. 
From Android documentation:
Set this flag if you would only like the sound, vibrate and ticker to be played if the notification is not already showing. 