### PR TITLE
Add support for specifying a delegate FirebaseMessagingService

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,6 @@ PushNotification.localNotification({
   priority: "high", // (optional) set notification priority, default: high
   visibility: "private", // (optional) set notification visibility, default: private
   importance: "high", // (optional) set notification importance, default: high
-  allowWhileIdle: false, // (optional) set notification to work while on doze, default: false
   ignoreInForeground: false, // (optional) if true, the notification will not be visible when the app is in the foreground (useful for parity with how iOS notifications appear)
   shortcutId: "shortcut-id", // (optional) If this notification is duplicative of a Launcher shortcut, sets the id of the shortcut, in case the Launcher wants to hide the shortcut, default undefined
   channelId: "your-custom-channel-id", // (optional) custom channelId, if the channel doesn't exist, it will be created with options passed above (importance, vibration, sound). Once the channel is created, the channel will not be update. Make sure your channelId is different if you change these options. If you have created a custom channel, it will apply options of the channel.
@@ -364,6 +363,7 @@ PushNotification.localNotificationSchedule({
   //... You can use all the options from localNotifications
   message: "My Notification Message", // (required)
   date: new Date(Date.now() + 60 * 1000), // in 60 secs
+  allowWhileIdle: false, // (optional) set notification to work while on doze, default: false
 });
 ```
 

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
@@ -18,18 +18,31 @@ import static com.dieam.reactnativepushnotification.modules.RNPushNotification.L
 
 public class RNPushNotificationListenerService extends FirebaseMessagingService {
 
-    private RNReceivedMessageHandler mMessageReceivedHandler = new RNReceivedMessageHandler(this);
+    private RNReceivedMessageHandler mMessageReceivedHandler;
+    private FirebaseMessagingService mFirebaseServiceDelegate;
+
+    public RNPushNotificationListenerService() {
+        super();
+        this.mMessageReceivedHandler = new RNReceivedMessageHandler(this);
+    }
+
+    public RNPushNotificationListenerService(FirebaseMessagingService delegate) {
+        super();
+        this.mFirebaseServiceDelegate = delegate;
+        this.mMessageReceivedHandler = new RNReceivedMessageHandler(delegate);
+    }
 
     @Override
     public void onNewToken(String token) {
         final String deviceToken = token;
+        final FirebaseMessagingService serviceRef = (this.mFirebaseServiceDelegate == null) ? this : this.mFirebaseServiceDelegate;
         Log.d(LOG_TAG, "Refreshed token: " + deviceToken);
 
         Handler handler = new Handler(Looper.getMainLooper());
         handler.post(new Runnable() {
             public void run() {
                 // Construct and load our normal React JS code bundle
-                final ReactInstanceManager mReactInstanceManager = ((ReactApplication) getApplication()).getReactNativeHost().getReactInstanceManager();
+                final ReactInstanceManager mReactInstanceManager = ((ReactApplication)serviceRef.getApplication()).getReactNativeHost().getReactInstanceManager();
                 ReactContext context = mReactInstanceManager.getCurrentReactContext();
                 // If it's constructed, send a notification
                 if (context != null) {


### PR DESCRIPTION
Fixes #1356 

We're using multiple push providers and thus need to use a delegate service for handling our notifications.

This PR adds ability to specify a delegate service during instantiation as this library will otherwise throw an NPE when attempting to invoke `getReactNativeHost()` when handling a remote message in RNReceivedMessageHandler.