### PR TITLE
Simple implement for setting image from remote notification

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNReceivedMessageHandler.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNReceivedMessageHandler.java
@@ -46,6 +46,12 @@ public class RNReceivedMessageHandler {
             bundle.putString("message", remoteNotification.getBody());
             bundle.putString("sound", remoteNotification.getSound());
             bundle.putString("color", remoteNotification.getColor());
+            Uri uri = remoteNotification.getImageUrl();
+            if(uri != null) {
+              String imageUrl = uri.toString();
+              bundle.putString("bigPictureUrl", imageUrl);
+              bundle.putString("largeIconUrl", imageUrl);
+            }
         }
 
         Map<String, String> notificationData = message.getData();


### PR DESCRIPTION
Simple implementation for setting image from remote notification

Platform: Android

Testing fcm payload:
```
{
    "registration_ids":["TOKEN"],
    "notification": {
        "title": "testing",
        "body": "gained 11.80 points to close at 835.67, up 1.43% on the day.",
        "image": "https://i.pravatar.cc/300"
  }
}
```