### PR TITLE
[iOS] Get push userInteraction from push-notification-ios

### DIFF
--- a/index.js
+++ b/index.js
@@ -346,11 +346,12 @@ Notifications._transformNotificationObject = function(data, isFromBackground = n
 
   if ( Platform.OS === 'ios' ) {
     const notifData = data.getData();
+    const userInteraction = data.getData().userInteraction === 1
 
     _notification = {
       id: notifData?.id,
       foreground: !isFromBackground,
-      userInteraction: isFromBackground,
+      userInteraction: userInteraction,
       message: data.getMessage(),
       data: notifData,
       badge: data.getBadgeCount(),


### PR DESCRIPTION
This PR changes `userInteraction` value source. According to https://github.com/react-native-community/push-notification-ios/pull/122 `push-notification-ios@^1.5.0` has built-in `userInteraction` parameter on native side. 