### PR TITLE
Fix for vibration on notifs for Android API >= 26

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ To use channels, create them at startup and pass the matching `channelId` throug
   );
 ```
 
-**NOTE: Without channel, remote notifications don't work**
+**NOTE: Without channel, notifications don't work**
 
 In the notifications options, you must provide a channel id with `channelId: "your-channel-id"`, if the channel doesn't exist the notification might not e triggered. Once the channel is created, the channel cannot be update. Make sure your `channelId` is different if you change these options. If you have created a channel in another way, it will apply options of the channel.
 

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -908,7 +908,7 @@ public class RNPushNotificationHelper {
         String soundName = channelInfo.hasKey("soundName") ? channelInfo.getString("soundName") : "default";
         int importance = channelInfo.hasKey("importance") ? channelInfo.getInt("importance") : 4;
         boolean vibrate = channelInfo.hasKey("vibrate") && channelInfo.getBoolean("vibrate");
-        long[] vibratePattern = vibrate ? new long[] { DEFAULT_VIBRATION } : null;
+        long[] vibratePattern = vibrate ? new long[] { 0, DEFAULT_VIBRATION } : null;
 
         NotificationManager manager = notificationManager();
 

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -446,7 +446,7 @@ public class RNPushNotificationHelper {
                 if (vibration == 0)
                     vibration = DEFAULT_VIBRATION;
 
-                vibratePattern = new long[]{0, vibration};
+                vibratePattern = new long[]{vibration};
 
                 notification.setVibrate(vibratePattern); 
             }


### PR DESCRIPTION
This fixes the vibration feature for notification for Android notifications for API >= 26. This pattern is used for the Notif Builder for API < 26 and it appears to work there as well.

Before:

```
<Sending Notif>
2020-10-04 12:37:03.630 1936-29464/? E/VibratorService: vibratorOff command failed (1).
2020-10-04 12:37:03.935 1936-29476/? E/VibratorService: vibratorOff command failed (1).
```

After:
```
<Sending Notif>
2020-10-04 12:07:16.037 1936-4760/? E/VibratorService: vibratorOff command failed (1).
2020-10-04 12:07:16.037 1936-4760/? E/VibratorService: vibratorOn command failed (1).
2020-10-04 12:07:16.438 1936-1936/? E/VibratorService: vibratorOff command failed (1).
```

Have tested this on a physical device as well and it works. This could lead to an obvious extension which is for users to specify a vibration pattern array when creating a channel.