### PR TITLE
implement 'bigLargeIcon' for Android notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,8 @@ PushNotification.localNotification({
   bigText: "My big text that will be shown when notification is expanded", // (optional) default: "message" prop
   subText: "This is a subText", // (optional) default: none
   bigPictureUrl: "https://www.example.tld/picture.jpg", // (optional) default: undefined
+  bigLargeIcon: "ic_launcher", // (optional) default: undefined
+  bigLargeIconUrl: "https://www.example.tld/bigicon.jpg", // (optional) default: undefined
   color: "red", // (optional) default: system default
   vibrate: true, // (optional) default: true
   vibration: 300, // vibration length in milliseconds, ignored if vibrate=false, default: 1000

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -376,6 +376,21 @@ public class RNPushNotificationHelper {
             NotificationCompat.Style style;
 
             if(bigPictureBitmap != null) {
+
+              // Big large icon
+              if(bigLargeIconBitmap == null) {
+                  int bigLargeIconResId = 0;
+
+                  String bigLargeIcon = bundle.getString("bigLargeIcon");
+
+                  if (bigLargeIcon != null && !bigLargeIcon.isEmpty()) {
+                    bigLargeIconResId = res.getIdentifier(bigLargeIcon, "mipmap", packageName);
+                    if (bigLargeIconResId != 0) {
+                      bigLargeIconBitmap = BitmapFactory.decodeResource(res, bigLargeIconResId);
+                    }
+                  }
+              }
+
               style = new NotificationCompat.BigPictureStyle()
                       .bigPicture(bigPictureBitmap)
                       .setBigContentTitle(title)

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -186,16 +186,17 @@ public class RNPushNotificationHelper {
 
     public void sendToNotificationCentre(final Bundle bundle) {
       RNPushNotificationPicturesAggregator aggregator = new RNPushNotificationPicturesAggregator(new RNPushNotificationPicturesAggregator.Callback() {
-        public void call(Bitmap largeIconImage, Bitmap bigPictureImage) {
-          sendToNotificationCentreWithPicture(bundle, largeIconImage, bigPictureImage);
+        public void call(Bitmap largeIconImage, Bitmap bigPictureImage, Bitmap bigLargeIconImage) {
+          sendToNotificationCentreWithPicture(bundle, largeIconImage, bigPictureImage, bigLargeIconImage);
         }
       });
 
       aggregator.setLargeIconUrl(context, bundle.getString("largeIconUrl"));
+      aggregator.setBigLargeIconUrl(context, bundle.getString("bigLargeIconUrl"));
       aggregator.setBigPictureUrl(context, bundle.getString("bigPictureUrl"));
     }
 
-    public void sendToNotificationCentreWithPicture(Bundle bundle, Bitmap largeIconBitmap, Bitmap bigPictureBitmap) {
+    public void sendToNotificationCentreWithPicture(Bundle bundle, Bitmap largeIconBitmap, Bitmap bigPictureBitmap, Bitmap bigLargeIconBitmap) {
         try {
             Class intentClass = getMainActivityClass();
             if (intentClass == null) {
@@ -378,7 +379,8 @@ public class RNPushNotificationHelper {
               style = new NotificationCompat.BigPictureStyle()
                       .bigPicture(bigPictureBitmap)
                       .setBigContentTitle(title)
-                      .setSummaryText(message);
+                      .setSummaryText(message)
+                      .bigLargeIcon(bigLargeIconBitmap);
             }
             else {
               style = new NotificationCompat.BigTextStyle().bigText(bigText);


### PR DESCRIPTION
Add support for [BigLargeIcon](https://developer.android.com/reference/android/app/Notification.BigPictureStyle#bigLargeIcon(android.graphics.Bitmap)), which is the large icon shown on the upper right when a picture or media notification is expanded (see [here](https://itnext.io/android-notification-bigpicturestyle-1f293e6cabaf) for a splendid explanation).

Currently, when you add a picture to a notification and use largeIcon for preview, when you expand the notification you will see both, the picture and it's same, just smaller preview on the upper right.
I think this doesn't look too nice and it's better to have the largeIcon disappear or set to something else (e.g. the app icon) in expanded view, which this change enables the users to.

That's also the reason why in the code I don't check for the bigLargeIcon to be present but always set it, which leads to the default behaviour that the largeIcon disappears when expanded.