### PR TITLE
Android: silent channel using playSound flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ To use channels, create them at startup and pass the matching `channelId` throug
       channelId: "channel-id", // (required)
       channelName: "My channel", // (required)
       channelDescription: "A channel to categorise your notifications", // (optional) default: undefined.
+      playSound: false, // (optional) default: true
       soundName: "default", // (optional) See `soundName` parameter of `localNotification` function
       importance: 4, // (optional) default: 4. Int value of the Android notification importance
       vibrate: true, // (optional) default: true. Creates the default vibration patten if true.

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -905,6 +905,7 @@ public class RNPushNotificationHelper {
         String channelId = channelInfo.getString("channelId");
         String channelName = channelInfo.getString("channelName");
         String channelDescription = channelInfo.hasKey("channelDescription") ? channelInfo.getString("channelDescription") : "";
+        boolean playSound = !channelInfo.hasKey("playSound") || channelInfo.getBoolean("playSound");
         String soundName = channelInfo.hasKey("soundName") ? channelInfo.getString("soundName") : "default";
         int importance = channelInfo.hasKey("importance") ? channelInfo.getInt("importance") : 4;
         boolean vibrate = channelInfo.hasKey("vibrate") && channelInfo.getBoolean("vibrate");
@@ -912,7 +913,7 @@ public class RNPushNotificationHelper {
 
         NotificationManager manager = notificationManager();
 
-        Uri soundUri = getSoundUri(soundName);
+        Uri soundUri = playSound ? getSoundUri(soundName) : null;
 
         return checkOrCreateChannel(manager, channelId, channelName, channelDescription, soundUri, importance, vibratePattern);
     }


### PR DESCRIPTION
Currently it isn't possible to make silent channels, and sending silent notifications to Android > 8 devices.
A playSound option is added to PushNotification.createChannel() to make it possible to create silent channels in Android. The same option exists in PushNotification.localNotification().

Related issues: https://github.com/zo0r/react-native-push-notification/issues/1432 and https://github.com/zo0r/react-native-push-notification/issues/1045