### PR TITLE
Replace deprecated local notification methods on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Fixed
 
+## [6.1.2] 2020-10-291
+
+### Fixed
+
+- (Android) Fix for vibration on notifs for Android API >= 26 [#1686](https://github.com/zo0r/react-native-push-notification/pull/1686)
+
 ## [6.1.1] 2020-09-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,13 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Fixed
 
-## [6.1.2] 2020-10-291
+## [6.1.3] 2020-11-09
+
+### Fixed
+
+- (Android) Null pointer exception when trying to create channel [#134](https://github.com/zo0r/react-native-push-notification/issues/1734)
+
+## [6.1.2] 2020-10-29
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -559,15 +559,15 @@ Provides you with a list of the app’s scheduled local notifications that are y
 
 Returns an array of local scheduled notification objects containing:
 
-| Name           | Type   | Description                               |
-| -------------- | ------ | ----------------------------------------- |
-| id             | number | The identifier of this notification.      |
-| date           | Date   | The fire date of this notification.       |
-| title          | string | The title of this notification.           |
-| message        | string | The message body of this notification.    |
-| soundName      | string | The sound name of this notification.      |
-| repeatInterval | number | The repeat interval of this notification. |
-| number         | number | App notification badge count number.      |
+| Name           | Type   | Description                                              |
+| -------------- | ------ | -------------------------------------------------------- |
+| id             | number | The identifier of this notification.                     |
+| date           | Date   | The fire date of this notification.                      |
+| title          | string | The title of this notification.                          |
+| message        | string | The message body of this notification.                   |
+| soundName      | string | The sound name of this notification.                     |
+| repeatInterval | number | (Android only) The repeat interval of this notification. |
+| number         | number | App notification badge count number.                     |
 
 ## Abandon Permissions
 
@@ -630,6 +630,10 @@ https://developer.android.com/training/monitoring-device-state/doze-standby
 
 (optional) Specify `repeatType` and optionally `repeatTime` (Android-only) while scheduling the local notification. Check the local notification example above.
 
+### iOS
+Property `repeatType` can only be `day`.
+
+### Android
 Property `repeatType` could be one of `month`, `week`, `day`, `hour`, `minute`, `time`. If specified as time, it should be accompanied by one more parameter `repeatTime` which should the number of milliseconds between each interval.
 
 ## Notification Actions

--- a/README.md
+++ b/README.md
@@ -496,8 +496,6 @@ PushNotification.cancelLocalNotifications({id: '123'});
 
 Cancels all scheduled notifications AND clears the notifications alerts that are in the notification centre.
 
-_NOTE: there is currently no api for removing specific notification alerts from the notification centre._
-
 ### 3) removeAllDeliveredNotifications
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -336,7 +336,6 @@ PushNotification.localNotification({
   invokeApp: true, // (optional) This enable click on actions to bring back the application to foreground or stay in background, default: true
 
   /* iOS only properties */
-  alertAction: "view", // (optional) default: view
   category: "", // (optional) default: empty string
 
   /* iOS and Android properties */

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -866,8 +866,8 @@ public class RNPushNotificationHelper {
           channel == null && channel_name != null && channel_description != null ||
           channel != null &&
           (
-            channel_name != null && !channel.getName().equals(channel_name) ||
-            channel_description != null && !channel.getDescription().equals(channel_description)
+            channel_name != null && !channel_name.equals(channel.getName()) ||
+            channel_description != null && !channel_description.equals(channel.getDescription())
           )
         ) {
             // If channel doesn't exist create a new one.

--- a/example/NotifService.js
+++ b/example/NotifService.js
@@ -93,7 +93,6 @@ export default class NotifService {
       timeoutAfter: null, // (optional) Specifies a duration in milliseconds after which this notification should be canceled, if it is not already canceled, default: null
 
       /* iOS only properties */
-      alertAction: 'view', // (optional) default: view
       category: '', // (optional) default: empty string
       
       /* iOS and Android properties */
@@ -135,7 +134,6 @@ export default class NotifService {
       timeoutAfter: null, // (optional) Specifies a duration in milliseconds after which this notification should be canceled, if it is not already canceled, default: null
     
       /* iOS only properties */
-      alertAction: 'view', // (optional) default: view
       category: '', // (optional) default: empty string
       
       /* iOS and Android properties */

--- a/index.js
+++ b/index.js
@@ -451,8 +451,12 @@ Notifications.scheduleLocalNotification = function() {
   return this.callNative('scheduleLocalNotification', arguments);
 };
 
-Notifications.cancelLocalNotifications = function() {
-  return this.callNative('cancelLocalNotifications', arguments);
+Notifications.cancelLocalNotifications = function(userInfo) {
+  if ( Platform.OS === 'ios' ) {
+    return this.callNative('removePendingNotificationRequests', [userInfo.id]);
+  } else {
+    return this.callNative('cancelLocalNotifications', [userInfo]);
+  }
 };
 
 Notifications.clearLocalNotification = function() {

--- a/index.js
+++ b/index.js
@@ -464,7 +464,11 @@ Notifications.clearLocalNotification = function() {
 };
 
 Notifications.cancelAllLocalNotifications = function() {
-  return this.callNative('cancelAllLocalNotifications', arguments);
+  if ( Platform.OS === 'ios' ) {
+    return this.callNative('removeAllPendingNotificationRequests', arguments);
+  } else if (Platform.OS === 'android') {
+    return this.callNative('cancelAllLocalNotifications', arguments);
+  }
 };
 
 Notifications.setApplicationIconBadgeNumber = function() {
@@ -512,13 +516,13 @@ Notifications.getScheduledLocalNotifications = function(callback) {
 			if(Platform.OS === 'ios'){
 				mappedNotifications = notifications.map(notif => {
 					return ({
-						soundName: notif.soundName,
+						soundName: notif?.sound,
 						repeatInterval: notif.repeatInterval,
-						id: notif.userInfo?.id,
-            date: new Date(notif.fireDate),
-						number: notif?.applicationIconBadgeNumber,
-						message: notif?.alertBody,
-						title: notif?.alertTitle,
+						id: notif.id,
+                        date: (notif.date ? new Date(notif.date) : null),
+						number: notif?.badge,
+						message: notif?.body,
+						title: notif?.title,
 					})
 				})
 			} else if(Platform.OS === 'android') {
@@ -538,7 +542,11 @@ Notifications.getScheduledLocalNotifications = function(callback) {
 		callback(mappedNotifications);
 	}
 
-	return this.callNative('getScheduledLocalNotifications', [mapNotifications]);
+  if(Platform.OS === 'ios'){
+    return this.callNative('getPendingNotificationRequests', [mapNotifications]);
+  } else {
+    return this.callNative('getScheduledLocalNotifications', [mapNotifications]);
+  }
 }
 
 Notifications.removeDeliveredNotifications = function() {

--- a/index.js
+++ b/index.js
@@ -253,20 +253,16 @@ Notifications.localNotificationSchedule = function(details) {
       fireDate: details.date.toISOString(),
       title: details.title,
       body: details.message,
-      soundName: soundName,
+      sound: soundName,
       category: details.category,
       userInfo: details.userInfo,
-      repeatInterval: details.repeatType,
+      repeats: (details.repeatType && details.repeatType == "day"),
     };
 
     if (details.number) {
-      iosDetails.applicationIconBadgeNumber = parseInt(details.number, 10);
+      iosDetails.badge = parseInt(details.number, 10);
     }
 
-    // ignore Android only repeatType
-    if (!details.repeatType || details.repeatType === 'time') {
-      delete iosDetails.repeatInterval;
-    }
     this.handler.addNotificationRequest(iosDetails);
   } else {
     if (details && typeof details.number === 'number') {
@@ -517,7 +513,6 @@ Notifications.getScheduledLocalNotifications = function(callback) {
 				mappedNotifications = notifications.map(notif => {
 					return ({
 						soundName: notif?.sound,
-						repeatInterval: notif.repeatInterval,
 						id: notif.id,
                         date: (notif.date ? new Date(notif.date) : null),
 						number: notif?.badge,

--- a/index.js
+++ b/index.js
@@ -453,7 +453,7 @@ Notifications.scheduleLocalNotification = function() {
 
 Notifications.cancelLocalNotifications = function(userInfo) {
   if ( Platform.OS === 'ios' ) {
-    return this.callNative('removePendingNotificationRequests', [userInfo.id]);
+    return this.callNative('removePendingNotificationRequests', [[userInfo.id]]);
   } else {
     return this.callNative('cancelLocalNotifications', [userInfo]);
   }

--- a/index.js
+++ b/index.js
@@ -176,15 +176,14 @@ Notifications.localNotification = function(details) {
     }
 
     // for valid fields see: https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html
-    // alertTitle only valid for apple watch: https://developer.apple.com/library/ios/documentation/iPhone/Reference/UILocalNotification_Class/#//apple_ref/occ/instp/UILocalNotification/alertTitle
 
-    this.handler.presentLocalNotification({
-      alertTitle: details.title,
-      alertBody: details.message,
-      alertAction: details.alertAction,
+    this.handler.addNotificationRequest({
+      id: (!details.id ? Math.floor(Math.random() * Math.pow(2, 32)).toString() : details.id),
+      title: details.title,
+      body: details.message,
+      badge: details.number,
+      sound: soundName,
       category: details.category,
-      soundName: soundName,
-      applicationIconBadgeNumber: details.number,
       userInfo: details.userInfo
     });
   } else {
@@ -250,14 +249,14 @@ Notifications.localNotificationSchedule = function(details) {
     }
 
     const iosDetails = {
+      id: (!details.id ? Math.floor(Math.random() * Math.pow(2, 32)).toString() : details.id),
       fireDate: details.date.toISOString(),
-      alertTitle: details.title,
-      alertBody: details.message,
-      category: details.category,
+      title: details.title,
+      body: details.message,
       soundName: soundName,
+      category: details.category,
       userInfo: details.userInfo,
       repeatInterval: details.repeatType,
-      category: details.category,
     };
 
     if (details.number) {
@@ -268,7 +267,7 @@ Notifications.localNotificationSchedule = function(details) {
     if (!details.repeatType || details.repeatType === 'time') {
       delete iosDetails.repeatInterval;
     }
-    this.handler.scheduleLocalNotification(iosDetails);
+    this.handler.addNotificationRequest(iosDetails);
   } else {
     if (details && typeof details.number === 'number') {
       if (isNaN(details.number)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-push-notification",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "React Native Local and Remote Notifications",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "git+ssh://git@github.com:zo0r/react-native-push-notification.git"
   },
   "peerDependencies": {
-    "@react-native-community/push-notification-ios": "^1.5.0",
+    "@react-native-community/push-notification-ios": "^1.7.4",
     "react-native": ">=0.33"
   },
   "author": "zo0r <http://zo0r.me>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-push-notification",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "description": "React Native Local and Remote Notifications",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "git+ssh://git@github.com:zo0r/react-native-push-notification.git"
   },
   "peerDependencies": {
-    "@react-native-community/push-notification-ios": "^1.7.4",
+    "@react-native-community/push-notification-ios": "^1.8.0",
     "react-native": ">=0.33"
   },
   "author": "zo0r <http://zo0r.me>",


### PR DESCRIPTION
As of [push-notification-ios@v1.7.0](https://github.com/react-native-push-notification-ios/push-notification-ios/releases/tag/v1.7.0), these iOS methods are deprecated:

- presentLocalNotification
- scheduleLocalNotification
- cancelAllLocalNotifications
- getScheduledLocalNotifications

This PR replaces those methods appropriately on iOS without changing the API of react-native-push-notification.

This fixes https://github.com/zo0r/react-native-push-notification/issues/1716

## 2 Breaking Changes
alertAction is deprecated as of iOS 10 and is not available in the new addNotificationRequest method.

It should also be noted that push-notification-ios@v1.4.1 had an unmentioned breaking change, requiring users to update their AppDelegate to use UNUserNotificationCenter and to stop using `application:didReceiveLocalNotification:` to receive notifications (this caused undefined notification details similar to #1488). I [opened an issue](https://github.com/react-native-push-notification-ios/push-notification-ios/issues/236) over there to hopefully update their documentation.

These changes will require the same update, so it should be mentioned as a breaking change (though this has been true since 8/18/2020)

## Depends on update to push-notification-ios
This depends on https://github.com/react-native-push-notification-ios/push-notification-ios/pull/237 so I have this marked as draft for now.