### PR TITLE
Update peerDependency `push-notification-ios`  to `^1.7.3`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "git+ssh://git@github.com:zo0r/react-native-push-notification.git"
   },
   "peerDependencies": {
-    "@react-native-community/push-notification-ios": "^1.5.0",
+    "@react-native-community/push-notification-ios": "^1.7.3",
     "react-native": ">=0.33"
   },
   "author": "zo0r <http://zo0r.me>",


### PR DESCRIPTION
I faced a bug about `userInteraction` variable, seems had fixed in version 1.7.3