### PR TITLE
setNotificationSilent()

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,14 +45,9 @@ android {
 }
 
 dependencies {
-    // Use either AndroidX library names or old/support library names based on major version of support lib
-    def supportLibVersion = safeExtGet('supportLibVersion', '27.1.1')
-    def supportLibMajorVersion = supportLibVersion.split('\\.')[0] as int
-    def appCompatLibName =  (supportLibMajorVersion < 20) ? "androidx.appcompat:appcompat" : "com.android.support:appcompat-v7"
-
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     testImplementation 'junit:junit:4.12'
-    implementation "$appCompatLibName:$supportLibVersion"
+    implementation "androidx.appcompat:appcompat:1.2.0"
     implementation 'com.facebook.react:react-native:+'
     implementation 'me.leolin:ShortcutBadger:1.1.22@aar'
     implementation "com.google.firebase:firebase-messaging:${safeExtGet('firebaseMessagingVersion', '21.1.0')}"

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -431,6 +431,8 @@ public class RNPushNotificationHelper {
                 soundUri = getSoundUri(soundName);
 
                 notification.setSound(soundUri);
+            } else {
+                notification.setNotificationSilent();
             }
 
             if (soundUri == null || Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {


### PR DESCRIPTION
Newer versions of androidx let us send silent notifications to a channel with sound. This isn't available in older versions so I had to change build.gradle.

The `setNotificationSilent()` method is also getting deprecated in the next versions and will be replaced with `setSilent()`. I have a doubt that the older build.gradle wasn't doing the right thing because it installed an older androidx version (1.0.0).

References:
- https://developer.android.com/jetpack/androidx/releases/appcompat
- https://developer.android.com/reference/androidx/core/app/NotificationCompat.Builder#setNotificationSilent()