### PR TITLE
Document `data` in getScheduledLocalNotifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,6 +586,7 @@ Returns an array of local scheduled notification objects containing:
 | soundName      | string | The sound name of this notification.                     |
 | repeatInterval | number | (Android only) The repeat interval of this notification. |
 | number         | number | App notification badge count number.                     |
+| data           | any    | The user info of this notification.                      |
 
 ## Abandon Permissions
 


### PR DESCRIPTION
I noticed that `userInfo`/`data` was being returned in the notifications array of the `getScheduledLocalNotifications` but was not properly documented. 

See https://github.com/zo0r/react-native-push-notification/blob/master/index.js#L546

I've also added this property to the @types package https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51720