### PR TITLE
fix(ios): foreground notification property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Fixed
 
 - (Android) Fix: Could not invoke RNPushNotification.getDeliveredNotifications. [#1878](https://github.com/zo0r/react-native-push-notification/issues/1878)
+- (fix) deep clone details and notifications. [#1793](https://github.com/zo0r/react-native-push-notification/issues/1793)
 
 ## [7.2.1] 2021-02-11
 

--- a/index.js
+++ b/index.js
@@ -351,7 +351,8 @@ Notifications._transformNotificationObject = function(data, isFromBackground = n
   if ( isFromBackground === null ) {
     isFromBackground = (
       data.foreground === false ||
-      AppState.currentState === 'background'
+      AppState.currentState === 'background' ||
+      AppState.currentState === 'unknown'
     );
   }
 


### PR DESCRIPTION
check if react native's app state is unknown to verify if
app came from background