### PR TITLE
Fix: Foreground notifications missing small icon

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNReceivedMessageHandler.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNReceivedMessageHandler.java
@@ -56,6 +56,12 @@ public class RNReceivedMessageHandler {
             bundle.putString("color", remoteNotification.getColor());
             bundle.putString("tag", remoteNotification.getTag());
             
+            if(remoteNotification.getIcon() != null) {
+              bundle.putString("smallIcon", remoteNotification.getIcon());
+            } else {
+              bundle.putString("smallIcon", "ic_notification");
+            }
+            
             if(remoteNotification.getChannelId() != null) {
               bundle.putString("channelId", remoteNotification.getChannelId());
             }


### PR DESCRIPTION
Resolves https://github.com/zo0r/react-native-push-notification/issues/1729