### PR TITLE
fix: added fallback firebaseMessagingVersion to android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,5 +55,5 @@ dependencies {
     implementation "$appCompatLibName:$supportLibVersion"
     implementation 'com.facebook.react:react-native:+'
     implementation 'me.leolin:ShortcutBadger:1.1.22@aar'
-    implementation "com.google.firebase:firebase-messaging:${safeExtGet('firebaseMessagingVersion', '+')}"
+    implementation "com.google.firebase:firebase-messaging:${safeExtGet('firebaseMessagingVersion', '21.1.0')}"
 }


### PR DESCRIPTION
- Firebase-iid is deprecated ([link1](https://firebase.google.com/support/release-notes/android#messaging_v22-0-0), [link2](https://firebase.google.com/docs/reference/android/com/google/firebase/iid/FirebaseInstanceId))
- This fix is temporary expedient (add the last version of Firebase-messaging SDK that has Firebase-iid dependency)

issues: #1979 #1981 #1984 