### PR TITLE
Replace deprecated Firebase API

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,7 +45,7 @@ android {
 dependencies {
     def supportLibVersion = safeExtGet('supportLibVersion', '27.1.1')
     def googlePlayServicesVersion = safeExtGet('googlePlayServicesVersion', '+')
-    def firebaseVersion = safeExtGet('firebaseVersion', '+')
+    def firebaseVersion = safeExtGet('firebaseVersion', '20.2.1')
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     testImplementation 'junit:junit:4.12'

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
@@ -1,154 +1,16 @@
 package com.dieam.reactnativepushnotification.modules;
 
-import java.util.Map;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 
-import android.app.ActivityManager;
-import android.app.ActivityManager.RunningAppProcessInfo;
-import android.app.Application;
-import android.os.Bundle;
-import android.os.Handler;
-import android.os.Looper;
-import android.util.Log;
-
-import com.dieam.reactnativepushnotification.helpers.ApplicationBadgeHelper;
-import com.facebook.react.ReactApplication;
-import com.facebook.react.ReactInstanceManager;
-import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReactContext;
-
-import org.json.JSONObject;
-
-import java.util.List;
-import java.util.Random;
-
-import static com.dieam.reactnativepushnotification.modules.RNPushNotification.LOG_TAG;
+import com.dieam.reactnativepushnotification.modules.RNReceivedMessageHandler;
 
 public class RNPushNotificationListenerService extends FirebaseMessagingService {
 
+    private RNReceivedMessageHandler mMessageReceivedHandler = new RNReceivedMessageHandler(this);
+
     @Override
     public void onMessageReceived(RemoteMessage message) {
-        String from = message.getFrom();
-        RemoteMessage.Notification remoteNotification = message.getNotification();
-
-        final Bundle bundle = new Bundle();
-        // Putting it from remoteNotification first so it can be overriden if message
-        // data has it
-        if (remoteNotification != null) {
-            // ^ It's null when message is from GCM
-            bundle.putString("title", remoteNotification.getTitle());
-            bundle.putString("message", remoteNotification.getBody());
-        }
-
-        for(Map.Entry<String, String> entry : message.getData().entrySet()) {
-            bundle.putString(entry.getKey(), entry.getValue());
-        }
-        JSONObject data = getPushData(bundle.getString("data"));
-        // Copy `twi_body` to `message` to support Twilio
-        if (bundle.containsKey("twi_body")) {
-            bundle.putString("message", bundle.getString("twi_body"));
-        }
-
-        if (data != null) {
-            if (!bundle.containsKey("message")) {
-                bundle.putString("message", data.optString("alert", null));
-            }
-            if (!bundle.containsKey("title")) {
-                bundle.putString("title", data.optString("title", null));
-            }
-            if (!bundle.containsKey("sound")) {
-                bundle.putString("soundName", data.optString("sound", null));
-            }
-            if (!bundle.containsKey("color")) {
-                bundle.putString("color", data.optString("color", null));
-            }
-
-            final int badge = data.optInt("badge", -1);
-            if (badge >= 0) {
-                ApplicationBadgeHelper.INSTANCE.setApplicationIconBadgeNumber(this, badge);
-            }
-        }
-
-        Log.v(LOG_TAG, "onMessageReceived: " + bundle);
-
-        // We need to run this on the main thread, as the React code assumes that is true.
-        // Namely, DevServerHelper constructs a Handler() without a Looper, which triggers:
-        // "Can't create handler inside thread that has not called Looper.prepare()"
-        Handler handler = new Handler(Looper.getMainLooper());
-        handler.post(new Runnable() {
-            public void run() {
-                // Construct and load our normal React JS code bundle
-                ReactInstanceManager mReactInstanceManager = ((ReactApplication) getApplication()).getReactNativeHost().getReactInstanceManager();
-                ReactContext context = mReactInstanceManager.getCurrentReactContext();
-                // If it's constructed, send a notification
-                if (context != null) {
-                    handleRemotePushNotification((ReactApplicationContext) context, bundle);
-                } else {
-                    // Otherwise wait for construction, then send the notification
-                    mReactInstanceManager.addReactInstanceEventListener(new ReactInstanceManager.ReactInstanceEventListener() {
-                        public void onReactContextInitialized(ReactContext context) {
-                            handleRemotePushNotification((ReactApplicationContext) context, bundle);
-                        }
-                    });
-                    if (!mReactInstanceManager.hasStartedCreatingInitialContext()) {
-                        // Construct it in the background
-                        mReactInstanceManager.createReactContextInBackground();
-                    }
-                }
-            }
-        });
-    }
-
-    private JSONObject getPushData(String dataString) {
-        try {
-            return new JSONObject(dataString);
-        } catch (Exception e) {
-            return null;
-        }
-    }
-
-    private void handleRemotePushNotification(ReactApplicationContext context, Bundle bundle) {
-
-        // If notification ID is not provided by the user for push notification, generate one at random
-        if (bundle.getString("id") == null) {
-            Random randomNumberGenerator = new Random(System.currentTimeMillis());
-            bundle.putString("id", String.valueOf(randomNumberGenerator.nextInt()));
-        }
-
-        Boolean isForeground = isApplicationInForeground();
-
-        RNPushNotificationJsDelivery jsDelivery = new RNPushNotificationJsDelivery(context);
-        bundle.putBoolean("foreground", isForeground);
-        bundle.putBoolean("userInteraction", false);
-        jsDelivery.notifyNotification(bundle);
-
-        // If contentAvailable is set to true, then send out a remote fetch event
-        if (bundle.getString("contentAvailable", "false").equalsIgnoreCase("true")) {
-            jsDelivery.notifyRemoteFetch(bundle);
-        }
-
-        Log.v(LOG_TAG, "sendNotification: " + bundle);
-
-        Application applicationContext = (Application) context.getApplicationContext();
-        RNPushNotificationHelper pushNotificationHelper = new RNPushNotificationHelper(applicationContext);
-        pushNotificationHelper.sendToNotificationCentre(bundle);
-    }
-
-    private boolean isApplicationInForeground() {
-        ActivityManager activityManager = (ActivityManager) this.getSystemService(ACTIVITY_SERVICE);
-        List<RunningAppProcessInfo> processInfos = activityManager.getRunningAppProcesses();
-        if (processInfos != null) {
-            for (RunningAppProcessInfo processInfo : processInfos) {
-                if (processInfo.processName.equals(getApplication().getPackageName())) {
-                    if (processInfo.importance == RunningAppProcessInfo.IMPORTANCE_FOREGROUND) {
-                        for (String d : processInfo.pkgList) {
-                            return true;
-                        }
-                    }
-                }
-            }
-        }
-        return false;
+        mMessageReceivedHandler.handleReceivedMessage(message);
     }
 }

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationRegistrationService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationRegistrationService.java
@@ -4,10 +4,9 @@ import android.app.IntentService;
 import android.content.Intent;
 import android.util.Log;
 
-import com.google.android.gms.tasks.OnSuccessListener;
-import com.google.firebase.iid.FirebaseInstanceId;
-import com.google.firebase.iid.InstanceIdResult;
+import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
+import com.google.firebase.messaging.FirebaseMessaging;
 
 
 import static com.dieam.reactnativepushnotification.modules.RNPushNotification.LOG_TAG;
@@ -24,12 +23,16 @@ public class RNPushNotificationRegistrationService extends IntentService {
     protected void onHandleIntent(Intent intent) {
         try {
             String SenderID = intent.getStringExtra("senderID");
-            Task<InstanceIdResult> t = FirebaseInstanceId.getInstance().getInstanceId();
-            t.addOnSuccessListener(new OnSuccessListener<InstanceIdResult>() {
+
+            FirebaseMessaging.getInstance().getToken().addOnCompleteListener(new OnCompleteListener<String>() {
                 @Override
-                public void onSuccess(InstanceIdResult instanceIdResult) {
-                    String token = instanceIdResult.getToken();
-                    sendRegistrationToken(token);
+                public void onComplete(@NonNull Task<String> task) {
+                    if (!task.isSuccessful()) {
+                        Log.e(LOG_TAG, "exception", task.getException());
+                        return;
+                    }
+
+                    sendRegistrationToken(task.getResult());
                 }
             });
         } catch (Exception e) {

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationRegistrationService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationRegistrationService.java
@@ -4,8 +4,11 @@ import android.app.IntentService;
 import android.content.Intent;
 import android.util.Log;
 
-import com.google.android.gms.gcm.GoogleCloudMessaging;
-import com.google.android.gms.iid.InstanceID;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.firebase.iid.FirebaseInstanceId;
+import com.google.firebase.iid.InstanceIdResult;
+import com.google.android.gms.tasks.Task;
+
 
 import static com.dieam.reactnativepushnotification.modules.RNPushNotification.LOG_TAG;
 
@@ -21,10 +24,14 @@ public class RNPushNotificationRegistrationService extends IntentService {
     protected void onHandleIntent(Intent intent) {
         try {
             String SenderID = intent.getStringExtra("senderID");
-            InstanceID instanceID = InstanceID.getInstance(this);
-            String token = instanceID.getToken(SenderID,
-                    GoogleCloudMessaging.INSTANCE_ID_SCOPE, null);
-            sendRegistrationToken(token);
+            Task<InstanceIdResult> t = FirebaseInstanceId.getInstance().getInstanceId();
+            t.addOnSuccessListener(new OnSuccessListener<InstanceIdResult>() {
+                @Override
+                public void onSuccess(InstanceIdResult instanceIdResult) {
+                    String token = instanceIdResult.getToken();
+                    sendRegistrationToken(token);
+                }
+            });
         } catch (Exception e) {
             Log.e(LOG_TAG, TAG + " failed to process intent " + intent, e);
         }

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNReceivedMessageHandler.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNReceivedMessageHandler.java
@@ -1,0 +1,163 @@
+package com.dieam.reactnativepushnotification.modules;
+
+import com.google.firebase.messaging.FirebaseMessagingService;
+import com.google.firebase.messaging.RemoteMessage;
+
+import android.app.ActivityManager;
+import android.app.Application;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import androidx.annotation.NonNull;
+import android.util.Log;
+
+import com.dieam.reactnativepushnotification.helpers.ApplicationBadgeHelper;
+import com.dieam.reactnativepushnotification.modules.RNPushNotificationHelper;
+import com.dieam.reactnativepushnotification.modules.RNPushNotificationJsDelivery;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
+
+import org.json.JSONObject;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static android.content.Context.ACTIVITY_SERVICE;
+import static com.dieam.reactnativepushnotification.modules.RNPushNotification.LOG_TAG;
+
+public class RNReceivedMessageHandler {
+    private FirebaseMessagingService mFirebaseMessagingService;
+
+    public RNReceivedMessageHandler(@NonNull FirebaseMessagingService service) {
+        this.mFirebaseMessagingService = service;
+    }
+
+    public void handleReceivedMessage(RemoteMessage message) {
+        final Bundle bundle = new Bundle();
+        RemoteMessage.Notification remoteNotification = message.getNotification();
+
+        // Putting it from remoteNotification first so it can be overriden if message
+        // data has it
+        if (remoteNotification != null) {
+            // ^ It's null when message is from GCM
+            bundle.putString("title", remoteNotification.getTitle());
+            bundle.putString("message", remoteNotification.getBody());
+        }
+
+        for(Map.Entry<String, String> entry : message.getData().entrySet()) {
+            bundle.putString(entry.getKey(), entry.getValue());
+        }
+        JSONObject data = getPushData(bundle.getString("data"));
+        // Copy `twi_body` to `message` to support Twilio
+        if (bundle.containsKey("twi_body")) {
+            bundle.putString("message", bundle.getString("twi_body"));
+        }
+
+        // Copy `body` to `message` to support Iterable
+        if (bundle.containsKey("itbl")) {
+            bundle.putString("message", bundle.getString("body"));
+        }
+
+        if (data != null) {
+            if (!bundle.containsKey("message")) {
+                bundle.putString("message", data.optString("alert", null));
+            }
+            if (!bundle.containsKey("title")) {
+                bundle.putString("title", data.optString("title", null));
+            }
+            if (!bundle.containsKey("sound")) {
+                bundle.putString("soundName", data.optString("sound", null));
+            }
+            if (!bundle.containsKey("color")) {
+                bundle.putString("color", data.optString("color", null));
+            }
+
+            final int badge = data.optInt("badge", -1);
+            if (badge >= 0) {
+                ApplicationBadgeHelper.INSTANCE.setApplicationIconBadgeNumber(mFirebaseMessagingService, badge);
+            }
+        }
+
+        // We need to run this on the main thread, as the React code assumes that is true.
+        // Namely, DevServerHelper constructs a Handler() without a Looper, which triggers:
+        // "Can't create handler inside thread that has not called Looper.prepare()"
+        Handler handler = new Handler(Looper.getMainLooper());
+        handler.post(new Runnable() {
+            public void run() {
+                // Construct and load our normal React JS code bundle
+                ReactInstanceManager mReactInstanceManager = ((ReactApplication) mFirebaseMessagingService.getApplication()).getReactNativeHost().getReactInstanceManager();
+                ReactContext context = mReactInstanceManager.getCurrentReactContext();
+                // If it's constructed, send a notification
+                if (context != null) {
+                    handleRemotePushNotification((ReactApplicationContext) context, bundle);
+                } else {
+                    // Otherwise wait for construction, then send the notification
+                    mReactInstanceManager.addReactInstanceEventListener(new ReactInstanceManager.ReactInstanceEventListener() {
+                        public void onReactContextInitialized(ReactContext context) {
+                            handleRemotePushNotification((ReactApplicationContext) context, bundle);
+                        }
+                    });
+                    if (!mReactInstanceManager.hasStartedCreatingInitialContext()) {
+                        // Construct it in the background
+                        mReactInstanceManager.createReactContextInBackground();
+                    }
+                }
+            }
+        });
+    }
+
+    private JSONObject getPushData(String dataString) {
+        try {
+            return new JSONObject(dataString);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private void handleRemotePushNotification(ReactApplicationContext context, Bundle bundle) {
+
+        // If notification ID is not provided by the user for push notification, generate one at random
+        if (bundle.getString("id") == null) {
+            Random randomNumberGenerator = new Random(System.currentTimeMillis());
+            bundle.putString("id", String.valueOf(randomNumberGenerator.nextInt()));
+        }
+
+        Boolean isForeground = isApplicationInForeground();
+
+        RNPushNotificationJsDelivery jsDelivery = new RNPushNotificationJsDelivery(context);
+        bundle.putBoolean("foreground", isForeground);
+        bundle.putBoolean("userInteraction", false);
+        jsDelivery.notifyNotification(bundle);
+
+        // If contentAvailable is set to true, then send out a remote fetch event
+        if (bundle.getString("contentAvailable", "false").equalsIgnoreCase("true")) {
+            jsDelivery.notifyRemoteFetch(bundle);
+        }
+
+        Log.v(LOG_TAG, "sendNotification: " + bundle);
+
+        Application applicationContext = (Application) context.getApplicationContext();
+        RNPushNotificationHelper pushNotificationHelper = new RNPushNotificationHelper(applicationContext);
+        pushNotificationHelper.sendToNotificationCentre(bundle);
+    }
+
+    private boolean isApplicationInForeground() {
+        ActivityManager activityManager = (ActivityManager) mFirebaseMessagingService.getSystemService(ACTIVITY_SERVICE);
+        List<ActivityManager.RunningAppProcessInfo> processInfos = activityManager.getRunningAppProcesses();
+        if (processInfos != null) {
+            for (ActivityManager.RunningAppProcessInfo processInfo : processInfos) {
+                if (processInfo.processName.equals(mFirebaseMessagingService.getApplication().getPackageName())) {
+                    if (processInfo.importance == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND) {
+                        for (String d : processInfo.pkgList) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNReceivedMessageHandler.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNReceivedMessageHandler.java
@@ -57,8 +57,8 @@ public class RNReceivedMessageHandler {
         }
 
         // Copy `body` to `message` to support Iterable
-        if (bundle.containsKey("itbl")) {
-            bundle.putString("message", bundle.getString("body"));
+        if (bundle.containsKey("itbl") && bundle.containsKey("body")) {
+            bundle.putString("message", bundle.getString("body"));            
         }
 
         if (data != null) {


### PR DESCRIPTION
I'm basically copying this fix https://github.com/zo0r/react-native-push-notification/commit/66243dd200efed95d72d2590ab3b0bf47fe22537

That commit was included in today's release of 7.3.0 but we are quite far behind that version so I just want to change as little as possible while getting our android build working again.