### PR TITLE
Fix assembleAndroidTest builds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,11 @@ android {
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
     buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)
         targetSdkVersion safeExtGet('targetSdkVersion', 28)


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Fixes an issue when building and running instrumented tests (e.g. Detox) for a React Native project on Android, the following build error was occurring:

```
> Task :react-native-push-notification:mergeExtDexDebugAndroidTest FAILED
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':react-native-push-notification:mergeExtDexDebugAndroidTest'.
> Could not resolve all files for configuration ':react-native-push-notification:debugAndroidTestRuntimeClasspath'.
   > Failed to transform firebase-datatransport-18.0.0.aar (com.google.firebase:firebase-datatransport:18.0.0) to match attributes {artifactType=android-dex, dexing-enable-desugaring=false, dexing-is-debuggable=true, dexing-min-sdk=23, org.gradle.status=release, org.gradle.usage=java-runtime}.
      > Execution failed for DexingNoClasspathTransform: C:\Users\some-user\.gradle\caches\transforms-2\files-2.1\4d61182c30ea6157b57a4d6f697f3dae\firebase-datatransport-18.0.0-runtime.jar.
         > Error while dexing.
           The dependency contains Java 8 bytecode. Please enable desugaring by adding the following to build.gradle
           android {
               compileOptions {
                   sourceCompatibility 1.8
                   targetCompatibility 1.8
               }
           }
           See https://developer.android.com/studio/write/java8-support.html for details. Alternatively, increase the minSdkVersion to 26 or above.
```

If an Android library uses Java 8 language features then it must declare `compileOptions` in its `build.gradle`.

> ...each module that uses Java 8 language features (either in its source code or through dependencies), update the module's build.gradle file, as shown below:

https://developer.android.com/studio/write/java8-support#supported_features

Fix is simply to add Java 8 `compileOptions` to the `build.gradle`. I've seen and fixed similar issues in other projects as well:

https://github.com/negativetwelve/react-native-ux-cam/issues/104
https://github.com/react-native-netinfo/react-native-netinfo/pull/466
https://github.com/snowplow-incubator/snowplow-react-native-tracker/pull/117

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
Made the change locally in my projects `node_modules`, then rebuilt the app, and it was successful 🎉 .