### PR TITLE
Allow HTML tags to be used for styling in bigText field only

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ PushNotification.localNotification({
   largeIcon: "ic_launcher", // (optional) default: "ic_launcher". Use "" for no large icon.
   largeIconUrl: "https://www.example.tld/picture.jpg", // (optional) default: undefined
   smallIcon: "ic_notification", // (optional) default: "ic_notification" with fallback for "ic_launcher". Use "" for default small icon.
-  bigText: "My big text that will be shown when notification is expanded", // (optional) default: "message" prop
+  bigText: "My big text that will be shown when notification is expanded. Styling can be done using HTML tags(see android docs for details)", // (optional) default: "message" prop
   subText: "This is a subText", // (optional) default: none
   bigPictureUrl: "https://www.example.tld/picture.jpg", // (optional) default: undefined
   bigLargeIcon: "ic_launcher", // (optional) default: undefined

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -22,11 +22,13 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.service.notification.StatusBarNotification;
+import android.text.Spanned;
 import android.util.Log;
 import androidx.core.app.RemoteInput;
 
 import androidx.annotation.RequiresApi;
 import androidx.core.app.NotificationCompat;
+import androidx.core.text.HtmlCompat;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableArray;
@@ -369,12 +371,6 @@ public class RNPushNotificationHelper {
             if (subText != null) {
                 notification.setSubText(subText);
             }
- 
-            String bigText = bundle.getString("bigText");
-
-            if (bigText == null) {
-                bigText = message;
-            }
 
             NotificationCompat.Style style;
 
@@ -401,7 +397,14 @@ public class RNPushNotificationHelper {
                       .bigLargeIcon(bigLargeIconBitmap);
             }
             else {
-              style = new NotificationCompat.BigTextStyle().bigText(bigText);
+              String bigText = bundle.getString("bigText");
+
+              if (bigText == null) {
+                  style = new NotificationCompat.BigTextStyle().bigText(message);
+              } else {
+                  Spanned styledText = HtmlCompat.fromHtml(bigText, HtmlCompat.FROM_HTML_MODE_LEGACY);
+                  style = new NotificationCompat.BigTextStyle().bigText(styledText);
+              }
             }
 
             notification.setStyle(style);


### PR DESCRIPTION
**Rationale:**

bigText field should be allowed to have HTML tags as a way to format the message since this has been already supported in android natively for a long time

**Expected behaviour:**

Allows a subset of html tags to be used as outlined [in this android documentation](https://developer.android.com/guide/topics/resources/string-resource#StylingWithHTML). Note that if user did not provided a bigText field but added html tags in message it self, it won't work as message field in iOS does not support HTML tags nor iOS has bigText property

**Testing:**

on bigText field, add some `<br/>` tags and see if it will put the subsequent string to the next line in android.

**Change:**

This is a small change, this merely decorates the bigText as Spanned Text