### PR TITLE
feat(android): Add user config. Add push notification bundle edit possibility before processing

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/interfaces/IRNPushNotificationBundleEditor.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/interfaces/IRNPushNotificationBundleEditor.java
@@ -1,0 +1,9 @@
+package com.dieam.reactnativepushnotification.interfaces;
+
+import android.os.Bundle;
+
+import com.google.firebase.messaging.RemoteMessage;
+
+public interface IRNPushNotificationBundleEditor {
+    public void editBundle(Bundle bundle, RemoteMessage message);
+}

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
@@ -1,5 +1,6 @@
 package com.dieam.reactnativepushnotification.modules;
 
+import com.dieam.reactnativepushnotification.types.RNPushNotificationUserConfig;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 
@@ -26,10 +27,21 @@ public class RNPushNotificationListenerService extends FirebaseMessagingService 
         this.mMessageReceivedHandler = new RNReceivedMessageHandler(this);
     }
 
+    public RNPushNotificationListenerService(RNPushNotificationUserConfig userConfig) {
+        super();
+        this.mMessageReceivedHandler = new RNReceivedMessageHandler(this, userConfig);
+    }
+
     public RNPushNotificationListenerService(FirebaseMessagingService delegate) {
         super();
         this.mFirebaseServiceDelegate = delegate;
         this.mMessageReceivedHandler = new RNReceivedMessageHandler(delegate);
+    }
+
+    public RNPushNotificationListenerService(FirebaseMessagingService delegate, RNPushNotificationUserConfig userConfig) {
+        super();
+        this.mFirebaseServiceDelegate = delegate;
+        this.mMessageReceivedHandler = new RNReceivedMessageHandler(delegate, userConfig);
     }
 
     @Override

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNReceivedMessageHandler.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNReceivedMessageHandler.java
@@ -1,5 +1,6 @@
 package com.dieam.reactnativepushnotification.modules;
 
+import com.dieam.reactnativepushnotification.types.RNPushNotificationUserConfig;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 
@@ -32,9 +33,15 @@ import static com.dieam.reactnativepushnotification.modules.RNPushNotification.L
 
 public class RNReceivedMessageHandler {
     private FirebaseMessagingService mFirebaseMessagingService;
+    private RNPushNotificationUserConfig userConfig;
 
     public RNReceivedMessageHandler(@NonNull FirebaseMessagingService service) {
         this.mFirebaseMessagingService = service;
+    }
+
+    public RNReceivedMessageHandler(@NonNull FirebaseMessagingService service, RNPushNotificationUserConfig userConfig) {
+        this.mFirebaseMessagingService = service;
+        this.userConfig = userConfig;
     }
 
     public void handleReceivedMessage(RemoteMessage message) {
@@ -127,6 +134,11 @@ public class RNReceivedMessageHandler {
         bundle.putParcelable("data", dataBundle);
 
         Log.v(LOG_TAG, "onMessageReceived: " + bundle);
+
+        if (this.userConfig != null && this.userConfig.getPushNotificationBundleEditor() != null) {
+            this.userConfig.getPushNotificationBundleEditor().editBundle(bundle, message);
+            Log.v(LOG_TAG, "onBundleEditedByUser: " + bundle);
+        }
 
         // We need to run this on the main thread, as the React code assumes that is true.
         // Namely, DevServerHelper constructs a Handler() without a Looper, which triggers:

--- a/android/src/main/java/com/dieam/reactnativepushnotification/types/RNPushNotificationUserConfig.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/types/RNPushNotificationUserConfig.java
@@ -1,0 +1,15 @@
+package com.dieam.reactnativepushnotification.types;
+
+import com.dieam.reactnativepushnotification.interfaces.IRNPushNotificationBundleEditor;
+
+public class RNPushNotificationUserConfig {
+    private IRNPushNotificationBundleEditor pushNotificationBundleEditor;
+
+    public void setPushNotificationBundleEditor(IRNPushNotificationBundleEditor pushNotificationBundleEditor) {
+        this.pushNotificationBundleEditor = pushNotificationBundleEditor;
+    }
+
+    public IRNPushNotificationBundleEditor getPushNotificationBundleEditor() {
+        return this.pushNotificationBundleEditor;
+    }
+}


### PR DESCRIPTION
Sometimes it's impossible to change the payload of push notifications on backend, and sometimes we need to add custom logic to push notification processing regarding an app status. In these cases, we need some mechanism of preprocessing the push data before processing it by the module. But due to the fact that there are no ways to do this with `RemoteMessage` type itself (which is the only input parameter), it requires some additional logic from the module. This PR introduces a possibility to edit the push notification bundle before start processing and allows extending module behaviour with user-defined config in the future.