### PR TITLE
Fix bug #2100 in cancelLocalNotifications() for Android

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationAttributes.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationAttributes.java
@@ -186,7 +186,7 @@ public class RNPushNotificationAttributes {
     @NonNull
     public static RNPushNotificationAttributes fromJson(String notificationAttributesJson) throws JSONException {
         JSONObject jsonObject = new JSONObject(notificationAttributesJson);
-        
+
         return new RNPushNotificationAttributes(jsonObject);
     }
 
@@ -244,6 +244,26 @@ public class RNPushNotificationAttributes {
         }
 
         return true;
+    }
+
+    /**
+    * Checks if the id of this RNPushNotificationAttributes is equal to the id
+    * provided within the userInfo map
+    *
+    * @param userInfo map of fields containing the id field to match
+    * @return true if ids match, false otherwise
+    */
+    public boolean idMatches(ReadableMap userInfo) {
+        try {
+            if(this.userInfo == null || userInfo == null) {
+              return false;
+            }
+            String userInfoId = userInfo.getString("id");
+            return this.id.equals(userInfoId);
+        } catch(Exception e) {
+            Log.e(LOG_TAG, "idMatches encountered an error", e);
+            return false;
+        }
     }
 
     public Bundle toBundle() {

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -265,13 +265,13 @@ public class RNPushNotificationHelper {
                         visibility = NotificationCompat.VISIBILITY_PRIVATE;
                 }
             }
-            
+
             String channel_id = bundle.getString("channelId");
 
             if(channel_id == null) {
                 channel_id = this.config.getNotificationDefaultChannelId();
             }
-            
+
             NotificationCompat.Builder notification = new NotificationCompat.Builder(context, channel_id)
                     .setContentTitle(title)
                     .setTicker(bundle.getString("ticker"))
@@ -279,7 +279,7 @@ public class RNPushNotificationHelper {
                     .setPriority(priority)
                     .setAutoCancel(bundle.getBoolean("autoCancel", true))
                     .setOnlyAlertOnce(bundle.getBoolean("onlyAlertOnce", false));
-            
+
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) { // API 24 and higher
                 // Restore showing timestamp on Android 7+
                 // Source: https://developer.android.com/reference/android/app/Notification.Builder.html#setShowWhen(boolean)
@@ -292,7 +292,7 @@ public class RNPushNotificationHelper {
                 // Changing Default mode of notification
                 notification.setDefaults(Notification.DEFAULT_LIGHTS);
             }
-      
+
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) { // API 20 and higher
               String group = bundle.getString("group");
 
@@ -355,7 +355,7 @@ public class RNPushNotificationHelper {
                     largeIconBitmap = BitmapFactory.decodeResource(res, largeIconResId);
                 }
             }
-            
+
             if (largeIconBitmap != null){
               notification.setLargeIcon(largeIconBitmap);
             }
@@ -369,7 +369,7 @@ public class RNPushNotificationHelper {
             if (subText != null) {
                 notification.setSubText(subText);
             }
- 
+
             String bigText = bundle.getString("bigText");
 
             if (bigText == null) {
@@ -464,32 +464,32 @@ public class RNPushNotificationHelper {
 
                 vibratePattern = new long[]{0, vibration};
 
-                notification.setVibrate(vibratePattern); 
+                notification.setVibrate(vibratePattern);
             }
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) { 
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
               // Define the shortcutId
               String shortcutId = bundle.getString("shortcutId");
-              
+
               if (shortcutId != null) {
                 notification.setShortcutId(shortcutId);
               }
- 
+
               Long timeoutAfter = (long) bundle.getDouble("timeoutAfter");
-  
+
               if (timeoutAfter != null && timeoutAfter >= 0) {
                 notification.setTimeoutAfter(timeoutAfter);
               }
             }
 
             Long when = (long) bundle.getDouble("when");
-  
+
             if (when != null && when >= 0) {
               notification.setWhen(when);
             }
 
             notification.setUsesChronometer(bundle.getBoolean("usesChronometer", false));
-                
+
             notification.setChannelId(channel_id);
             notification.setContentIntent(pendingIntent);
 
@@ -710,7 +710,7 @@ public class RNPushNotificationHelper {
     @RequiresApi(api = Build.VERSION_CODES.M)
     public WritableArray getDeliveredNotifications() {
       WritableArray result = Arguments.createArray();
-  
+
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
         return result;
       }
@@ -781,7 +781,7 @@ public class RNPushNotificationHelper {
                 String notificationAttributesJson = scheduledNotificationsPersistence.getString(id, null);
                 if (notificationAttributesJson != null) {
                     RNPushNotificationAttributes notificationAttributes = fromJson(notificationAttributesJson);
-                    if (notificationAttributes.matches(userInfo)) {
+                    if (notificationAttributes.idMatches(userInfo)) {
                         cancelScheduledNotification(id);
                     }
                 }
@@ -828,10 +828,10 @@ public class RNPushNotificationHelper {
 
     public List<String> listChannels() {
       List<String> channels = new ArrayList<>();
-      
+
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
           return channels;
-      
+
       NotificationManager manager = notificationManager();
 
       if (manager == null)
@@ -849,7 +849,7 @@ public class RNPushNotificationHelper {
     public boolean channelBlocked(String channel_id) {
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
           return false;
-      
+
       NotificationManager manager = notificationManager();
 
       if (manager == null)
@@ -866,7 +866,7 @@ public class RNPushNotificationHelper {
     public boolean channelExists(String channel_id) {
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
           return false;
-      
+
       NotificationManager manager = notificationManager();
 
       if (manager == null)
@@ -880,7 +880,7 @@ public class RNPushNotificationHelper {
     public void deleteChannel(String channel_id) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
             return;
-        
+
         NotificationManager manager = notificationManager();
 
         if (manager == null)
@@ -952,7 +952,7 @@ public class RNPushNotificationHelper {
 
         return checkOrCreateChannel(manager, channelId, channelName, channelDescription, soundUri, importance, vibratePattern);
     }
-    
+
     public boolean isApplicationInForeground() {
         ActivityManager activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
         List<RunningAppProcessInfo> processInfos = activityManager.getRunningAppProcesses();


### PR DESCRIPTION
cancelLocalNotifications() does not work on Android due to an implementation error. This PR fixes the issue #2100.