### PR TITLE
Fix 2122

### DIFF
--- a/component/index.android.js
+++ b/component/index.android.js
@@ -36,8 +36,8 @@ NotificationsComponent.prototype.unsubscribeFromTopic = function(topic) {
 	RNPushNotification.unsubscribeFromTopic(topic);
 };
 
-NotificationsComponent.prototype.cancelLocalNotifications = function(details) {
-	RNPushNotification.cancelLocalNotifications(details);
+NotificationsComponent.prototype.cancelLocalNotification = function(details) {
+	RNPushNotification.cancelLocalNotification(details);
 };
 
 NotificationsComponent.prototype.clearLocalNotification = function(details, tag) {


### PR DESCRIPTION
Fixes canceling notifications on Android.

See:  https://github.com/zo0r/react-native-push-notification/issues/2122