### PR TITLE
Fix iOS repeated notification timing

### DIFF
--- a/index.js
+++ b/index.js
@@ -252,9 +252,9 @@ Notifications.localNotificationSchedule = function({...details}) {
     }
     
     const repeatsComponent = {
-      second: details.repeatType == "minute",
-      minute: details.repeatType == "hour",
-      hour: details.repeatType == "day",
+      second: ['minute', 'hour', 'day', 'week', 'month'].includes(details.repeatType),
+      minute: ['hour', 'day', 'week', 'month'].includes(details.repeatType),
+      hour: ['day', 'week', 'month'].includes(details.repeatType),
       day: details.repeatType == "month",
       dayOfWeek: details.repeatType == "week",
     };


### PR DESCRIPTION
For repetition over larger time intervals, the smaller time intervals within `repeatsComponent` need to be set to `true` in order to ensure the notification is delivered at the correct time. Without this fix, iOS scheduled repeating notifications are not sent correctly and do not match the Android behaviour. 

I have tested this PR on my own app in prod and it fixes the issue correctly.

#2147 may be related.