### PR TITLE
Raise @react-native-community/push-notification-ios version

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -245,7 +245,7 @@ PODS:
     - React-Core (= 0.63.3)
     - React-cxxreact (= 0.63.3)
     - React-jsi (= 0.63.3)
-  - RNCPushNotificationIOS (1.10.0):
+  - RNCPushNotificationIOS (1.10.1):
     - React-Core
   - Yoga (1.14.0)
 
@@ -367,9 +367,9 @@ SPEC CHECKSUMS:
   React-RCTText: 65a6de06a7389098ce24340d1d3556015c38f746
   React-RCTVibration: 8e9fb25724a0805107fc1acc9075e26f814df454
   ReactCommon: 4167844018c9ed375cc01a843e9ee564399e53c3
-  RNCPushNotificationIOS: 5ee247e594d0b5df3cd7be74b51035a0d91807eb
+  RNCPushNotificationIOS: 87b8d16d3ede4532745e05b03c42cff33a36cc45
   Yoga: 7d13633d129fd179e01b8953d38d47be90db185a
 
 PODFILE CHECKSUM: 9f7efe26f7ad5184f28ac62478069370942924e2
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.2

--- a/example/package.json
+++ b/example/package.json
@@ -11,7 +11,7 @@
     "pod-install": "cd ios && pod install"
   },
   "dependencies": {
-    "@react-native-community/push-notification-ios": "^1.7.0",
+    "@react-native-community/push-notification-ios": "^1.10.1",
     "react": "16.13.1",
     "react-native": "0.63.3",
     "react-native-push-notification": "zo0r/react-native-push-notification#dev"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "git+ssh://git@github.com:zo0r/react-native-push-notification.git"
   },
   "peerDependencies": {
-    "@react-native-community/push-notification-ios": "^1.10.0",
+    "@react-native-community/push-notification-ios": "^1.10.1",
     "react-native": ">=0.33"
   },
   "author": "zo0r <http://zo0r.me>",


### PR DESCRIPTION
The latest version includes an important fix to prevent the app crashing on iOS 11 devices.

Reference: https://github.com/react-native-push-notification/ios/commit/f2f28cf08f0b6b3f97a3ce799d7b1a662e59edf5