### PR TITLE
Expose `onNotification` event listener via new api `onNotificationOpenedApp`

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,20 @@ Notification object example:
     data: {}, // OBJECT: The push data or the defined userInfo in local notifications
 }
 ```
+```js
+PushNotification.onNotificationOpenedApp(handler: (notification: Object) => EmitterSubscription)
+```
+
+EXAMPLE:
+
+```js
+useEffect(() => {
+  const subscription = PushNotification.onNotificationOpenedApp((notification) => {
+    console.log('Notification was opened', notification)
+  })
+  return () => subscription.remove()
+}, [])
+```
 
 ## Local Notifications
 

--- a/component/index.android.js
+++ b/component/index.android.js
@@ -109,6 +109,7 @@ NotificationsComponent.prototype.addEventListener = function(type, handler) {
   }
 
 	_notifHandlers.set(type, listener);
+	return listener
 };
 
 NotificationsComponent.prototype.removeEventListener = function(type, handler) {

--- a/index.js
+++ b/index.js
@@ -633,6 +633,12 @@ Notifications.setNotificationCategories = function() {
   return this.callNative('setNotificationCategories', arguments);
 }
 
+Notifications.onNotificationOpenedApp = function (callback) {
+  return this.callNative('addEventListener', ['notification', (notification) => {
+    callback(this._transformNotificationObject(notification, true))
+  }]);
+}
+
 // https://developer.android.com/reference/android/app/NotificationManager#IMPORTANCE_DEFAULT
 Notifications.Importance = Object.freeze({
   DEFAULT: 3,


### PR DESCRIPTION
This new api was inspired from `@react-native-firebase/messaging`.

I was struggling trying to configure navigation to a particular screen when a notification was pressed. All the examples I found does not provide full freedom or good explanation on how this can be configured. I was inspired from a post I found on medium.com (https://medium.com/cybermonkey/deep-linking-push-notifications-with-react-navigation-5fce260ccca2). I found it one day and I was wondering why can't this be done with `react-native-push-notifications`.

**An example with usage can be found in the README.** 

**Also an example of integration with react-navigation via deep linking was added.**