### PR TITLE
Use root locale when changing case in java

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static com.dieam.reactnativepushnotification.modules.RNPushNotification.LOG_TAG;
@@ -230,7 +231,7 @@ public class RNPushNotificationHelper {
             final String priorityString = bundle.getString("priority");
 
             if (priorityString != null) {
-                switch (priorityString.toLowerCase()) {
+                switch (priorityString.toLowerCase(Locale.ROOT)) {
                     case "max":
                         priority = NotificationCompat.PRIORITY_MAX;
                         break;
@@ -255,7 +256,7 @@ public class RNPushNotificationHelper {
             final String visibilityString = bundle.getString("visibility");
 
             if (visibilityString != null) {
-                switch (visibilityString.toLowerCase()) {
+                switch (visibilityString.toLowerCase(Locale.ROOT)) {
                     case "private":
                         visibility = NotificationCompat.VISIBILITY_PRIVATE;
                         break;


### PR DESCRIPTION
Not setting locale for language/country neutral operation may cause bug depending on the default locale.
See https://docs.oracle.com/javase/7/docs/api/java/util/Locale.html#ROOT

Note: I am just searching for toLowerCase() and toUppercase() in my project's dependencies and send the same PR, in order to potentially raise the awareness. Although I've seen the lack of explicit locale has caused issues for us, I am not sure if react-native-push-notification is actually affected.

Example related issue: joltup/rn-fetch-blob#573