### PR TITLE
substitute jcenter for  mavenCentral

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,6 @@ buildscript {
     repositories {
         mavenCentral()
         google()
-        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.0'
@@ -13,7 +12,6 @@ allprojects {
     repositories {
         mavenCentral()
         google()
-        jcenter()
     }
 }
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -39,4 +39,5 @@ allprojects {
         }
         google()
         maven { url 'https://www.jitpack.io' }
+    }
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:3.5.2")
@@ -22,7 +22,6 @@ buildscript {
 
 allprojects {
     repositories {
-        mavenLocal()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url("$rootDir/../node_modules/react-native/android")
@@ -31,9 +30,13 @@ allprojects {
             // Android JSC is installed from npm
             url("$rootDir/../node_modules/jsc-android/dist")
         }
-
+        mavenCentral {
+            // We don't want to fetch react-native from Maven Central as there are
+            // older versions over there.
+            content {
+                excludeGroup "com.facebook.react"
+            }
+        }
         google()
-        jcenter()
         maven { url 'https://www.jitpack.io' }
-    }
 }


### PR DESCRIPTION
Since Jcenter is deprecated and having issues it might be good to use mavenCentral instead. Dont know how to test if this is a fix at the moment or if it works with this projects dependencies. Never done a PR on a package like this before.