### PR TITLE
Add possibility to use custom handlers on 'handleReceivedMessage'

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNReceivedMessageCustomHandler.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNReceivedMessageCustomHandler.java
@@ -1,0 +1,7 @@
+package com.dieam.reactnativepushnotification.modules;
+
+import android.os.Bundle;
+
+public interface RNReceivedMessageCustomHandler {
+    void onMessageReceived(Bundle bundle);
+}

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNReceivedMessageHandler.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNReceivedMessageHandler.java
@@ -23,6 +23,7 @@ import com.facebook.react.bridge.ReactContext;
 
 import org.json.JSONObject;
 
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.List;
 import java.security.SecureRandom;
@@ -32,6 +33,8 @@ import static com.dieam.reactnativepushnotification.modules.RNPushNotification.L
 
 public class RNReceivedMessageHandler {
     private FirebaseMessagingService mFirebaseMessagingService;
+
+    public static List<RNReceivedMessageCustomHandler> CustomHandlers = new ArrayList();
 
     public RNReceivedMessageHandler(@NonNull FirebaseMessagingService service) {
         this.mFirebaseMessagingService = service;
@@ -127,6 +130,10 @@ public class RNReceivedMessageHandler {
         bundle.putParcelable("data", dataBundle);
 
         Log.v(LOG_TAG, "onMessageReceived: " + bundle);
+
+        for (RNReceivedMessageCustomHandler handler : CustomHandlers) {
+            handler.onMessageReceived(bundle);
+        }
 
         // We need to run this on the main thread, as the React code assumes that is true.
         // Namely, DevServerHelper constructs a Handler() without a Looper, which triggers:


### PR DESCRIPTION
`RNReceivedMessageCustomHandler` is required for applying custom logic with the received message.

For example our cases:
- sync app data state (we send specific silent push without 'message')
- remove some notifications from the 'notification center' by some filters (we send specific silent push without 'message')
- track push was delivered
