### PR TITLE
feat: add method to get fcm token

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -163,6 +163,20 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
         FirebaseMessaging.getInstance().unsubscribeFromTopic(topic);
     }
 
+       
+    @ReactMethod
+    public void getFCMToken(final Promise promise) {
+        FirebaseMessaging.getInstance().getToken()
+                .addOnCompleteListener(task -> {
+                    if (!task.isSuccessful()) {
+                        Log.e(LOG_TAG, "exception", task.getException());
+                        promise.reject(task.getException());
+                    } else {
+                        promise.resolve(task.getResult());
+                    }
+                });
+    }
+
     @ReactMethod
     public void presentLocalNotification(ReadableMap details) {
         Bundle bundle = Arguments.toBundle(details);

--- a/component/index.android.js
+++ b/component/index.android.js
@@ -36,6 +36,18 @@ NotificationsComponent.prototype.unsubscribeFromTopic = function(topic) {
 	RNPushNotification.unsubscribeFromTopic(topic);
 };
 
+NotificationsComponent.prototype.getFCMToken = function() {
+	return new Promise(function(resolve, reject) {
+		RNPushNotification.getFCMToken()
+		  .then(function(token) {
+			resolve(token);
+		  })
+		  .catch(function(err) {
+			reject(err);
+		  });
+	  });
+};
+
 NotificationsComponent.prototype.cancelLocalNotification = function(details) {
 	RNPushNotification.cancelLocalNotification(details);
 };

--- a/index.js
+++ b/index.js
@@ -475,6 +475,10 @@ Notifications.unsubscribeFromTopic = function () {
   return this.callNative('unsubscribeFromTopic', arguments);
 };
 
+Notifications.getFCMToken = function () {
+  return this.callNative('getFCMToken', arguments);
+};
+
 Notifications.presentLocalNotification = function() {
   return this.callNative('presentLocalNotification', arguments);
 };


### PR DESCRIPTION
- Implement a method to retrieve the FCM token upon request. I require this functionality in my app as I only need to obtain the FCM token once when the app is opened. I prefer not to use the onRegister method as it triggers continuously.

Goes with the following PR in [react-native-push-notification/ios](https://github.com/react-native-push-notification/ios): https://github.com/react-native-push-notification/ios/pull/410